### PR TITLE
Integrate additional MediaMTX API endpoints

### DIFF
--- a/mediamtx-stream-manager.sh
+++ b/mediamtx-stream-manager.sh
@@ -1730,6 +1730,7 @@ mediamtx_delete_path_config() {
 
 # List all active paths (runtime state)
 # Usage: mediamtx_list_paths [itemsPerPage] [page]
+# shellcheck disable=SC2120  # Optional parameters with defaults
 mediamtx_list_paths() {
     local items_per_page="${1:-1000}"
     local page="${2:-0}"
@@ -1789,6 +1790,7 @@ mediamtx_get_rtsp_conn() {
 # -----------------------------------------------------------------------------
 
 # List all RTSP sessions
+# shellcheck disable=SC2120  # Optional parameters with defaults
 mediamtx_list_rtsp_sessions() {
     local items_per_page="${1:-1000}"
     local page="${2:-0}"
@@ -1829,6 +1831,7 @@ mediamtx_get_rtsps_conn() {
 # -----------------------------------------------------------------------------
 
 # List all RTSPS sessions
+# shellcheck disable=SC2120  # Optional parameters with defaults
 mediamtx_list_rtsps_sessions() {
     local items_per_page="${1:-1000}"
     local page="${2:-0}"
@@ -1852,6 +1855,7 @@ mediamtx_kick_rtsps_session() {
 # -----------------------------------------------------------------------------
 
 # List all RTMP connections
+# shellcheck disable=SC2120  # Optional parameters with defaults
 mediamtx_list_rtmp_conns() {
     local items_per_page="${1:-1000}"
     local page="${2:-0}"
@@ -1898,6 +1902,7 @@ mediamtx_kick_rtmps_conn() {
 # -----------------------------------------------------------------------------
 
 # List all SRT connections
+# shellcheck disable=SC2120  # Optional parameters with defaults
 mediamtx_list_srt_conns() {
     local items_per_page="${1:-1000}"
     local page="${2:-0}"
@@ -1921,6 +1926,7 @@ mediamtx_kick_srt_conn() {
 # -----------------------------------------------------------------------------
 
 # List all WebRTC sessions
+# shellcheck disable=SC2120  # Optional parameters with defaults
 mediamtx_list_webrtc_sessions() {
     local items_per_page="${1:-1000}"
     local page="${2:-0}"


### PR DESCRIPTION
Add comprehensive REST API integration covering all MediaMTX v1.15.5 endpoints without any breaking changes to existing functionality.

Stream Manager (v1.4.3):
- Generic API call wrapper with proper HTTP status handling
- Instance info endpoint (/v3/info) for version and uptime
- Global and path defaults configuration management
- Dynamic path CRUD (add/delete/patch/replace) without restart
- RTSP/RTSPS connection and session management with kick support
- RTMP/RTMPS connection management with disconnect capability
- SRT connection management
- WebRTC session management
- HLS muxer monitoring
- Recording management and segment deletion
- JWT JWKS credential refresh
- Utility functions for connection counting and health checks

Metrics Exporter (v1.1.0):
- MediaMTX version and uptime from /v3/info
- RTSP session and connection counts
- RTSPS (secure) session counts
- RTMP/RTMPS connection counts
- WebRTC session counts
- SRT connection counts
- HLS muxer counts
- Recording counts
- Total connections across all protocols

All new functions are additive - no existing behavior is modified.