### PR TITLE
Engineering excellence review: fix 9 CRITICAL defects, repair test suite, wire CI

### DIFF
--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -484,12 +484,44 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ===========================================================================
-  # Job 7: Final Summary
+  # Job 7: Bats Test Suite (Required)
+  # ===========================================================================
+  bats-tests:
+    name: Bats Tests
+    runs-on: ubuntu-latest
+    needs: discover-scripts
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install bats
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bats
+
+      - name: Run bats test suite
+        run: |
+          echo "============================================"
+          echo "Bats Test Suite: $(bats --version)"
+          echo "============================================"
+          # Keep bats' working files off any shared /tmp cleanup path
+          export TMPDIR="${RUNNER_TEMP:-/tmp}"
+          export BATS_TMPDIR="${RUNNER_TEMP:-/tmp}"
+
+          if bats --print-output-on-failure --timing tests/; then
+            echo "All bats tests passed"
+          else
+            echo "::error::Bats tests failed"
+            exit 1
+          fi
+
+  # ===========================================================================
+  # Job 8: Final Summary
   # ===========================================================================
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [discover-scripts, bash-syntax, shellcheck, shfmt, bashate, security-scan]
+    needs: [discover-scripts, bash-syntax, shellcheck, shfmt, bashate, security-scan, bats-tests]
     if: always()
     steps:
       - name: Generate Comprehensive Summary
@@ -506,7 +538,7 @@ jobs:
             echo ""
 
             # Determine overall result
-            if [[ "${{ needs.bash-syntax.result }}" == "success" && "${{ needs.shellcheck.result }}" == "success" ]]; then
+            if [[ "${{ needs.bash-syntax.result }}" == "success" && "${{ needs.shellcheck.result }}" == "success" && "${{ needs.bats-tests.result }}" == "success" ]]; then
               echo "### All Required Checks Passed"
             else
               echo "### Required Checks Failed"
@@ -520,6 +552,7 @@ jobs:
             echo "|-------|------|--------|-------------|"
             echo "| **Bash Syntax** | Required | ${{ needs.bash-syntax.result == 'success' && 'Passed' || 'Failed' }} | Validates script syntax with \`bash -n\` |"
             echo "| **ShellCheck** | Required | ${{ needs.shellcheck.result == 'success' && 'Passed' || 'Failed' }} | Static analysis for bugs and issues |"
+            echo "| **Bats Tests** | Required | ${{ needs.bats-tests.result == 'success' && 'Passed' || 'Failed' }} | Unit and regression test suite |"
             echo "| **shfmt** | Advisory | ${{ needs.shfmt.result == 'success' && 'Passed' || 'Warnings' }} | Code formatting consistency |"
             echo "| **bashate** | Advisory | ${{ needs.bashate.result == 'success' && 'Passed' || 'Warnings' }} | OpenStack style guidelines |"
             echo "| **Security** | Advisory | ${{ needs.security-scan.result == 'success' && 'Passed' || 'Warnings' }} | Security anti-pattern detection |"
@@ -646,6 +679,13 @@ jobs:
             failed=1
           else
             echo "ShellCheck: passed"
+          fi
+
+          if [[ "${{ needs.bats-tests.result }}" != "success" ]]; then
+            echo "::error::Bats test suite failed"
+            failed=1
+          else
+            echo "Bats tests: passed"
           fi
 
           echo ""

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ config.local.*
 *.backup
 *.orig
 *.bkp
+.review-tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lyrebird-stream-manager.sh` updated to v1.4.4
   - Restructured API validation to preserve curl exit status for better error detection
   - Replaced `curl|grep` pattern with explicit exit code checking
+- CI now runs the `bats` test suite as a required check (previously never run)
+- Documented MediaMTX support through v1.19.x (endpoints/assets unchanged from v1.15.x)
+
+### Fixed (Engineering Excellence Review, 2026-07)
+Full line-by-line audit; see `docs/ENGINEERING-REVIEW-2026-07.md`. Each fix ships
+with a regression test. Highlights (all verified against the code):
+- **USB persistent naming never worked** — `usb-audio-mapper.sh` emitted every
+  udev rule as a comment (a literal `\n` collapsed the comment and rule onto one
+  `#`-prefixed line). Also fixed an injection-prone card-name sanitizer.
+- **FFmpeg streams did not auto-restart** — the supervisor wrapper died on the
+  first FFmpeg failure (bare `wait` under `set -euo pipefail`) and again when the
+  transient launcher PID exited. Restored the wrapper's backoff-restart loop.
+- **Per-device audio config was ignored** — `lyrebird-mic-check.sh` wrote
+  `DEVICE_<name>_*` keys in the wrong case for the stream manager's uppercase
+  lookup; a "high quality" mic silently ran at defaults (and `--validate` passed).
+- **ntfy/Pushover alerts were silently dropped** and falsely reported as sent.
+- **Prometheus scrape was rejected** — duplicate `# HELP`/`# TYPE` lines.
+- **Self-update always failed** — the updater deadlocked on its own lock after
+  `exec`.
+- **Orchestrator interactive delegations couldn't read input** (backgrounded
+  child stdin was `/dev/null`) — the Quick Setup Wizard could not map devices.
+- **Storage cleanup halted on a 0-byte file** (disk fill risk); emergency cleanup
+  no longer deletes unrelated `/var/log/*.gz` or ignores `--dry-run`.
+- **Diagnostics aborted on a healthy host** — `grep -c … || echo 0` produced a
+  `0\n0` arithmetic error under `set -e`.
+- **Webhook/JSON output is now valid** for control characters and backslashes.
+- **Test suite repaired** — 159 tests silently never ran; source guards + `set -e`
+  handling restored so all tests execute (and CI enforces them).
 
 ## [1.4.2] - 2025-12-19
 

--- a/docs/ENGINEERING-REVIEW-2026-07.md
+++ b/docs/ENGINEERING-REVIEW-2026-07.md
@@ -46,6 +46,29 @@ this produces **silent mid-run aborts** — found independently in four files:
 
 This class is the highest-leverage thing to fix and to guard with tests.
 
+### Remediation status (updated as fixes land)
+
+| Item | Status |
+|------|--------|
+| Test harness (159 hidden tests, `set -e` leak) + CI wiring | ✅ fixed |
+| C1 udev rules commented out + H7 sanitizer injection | ✅ fixed |
+| C2/C3 FFmpeg wrapper auto-restart (`wait`, parent-PID) | ✅ fixed (+ E2E) |
+| C4 mic-check ↔ stream-manager device-config case | ✅ fixed |
+| C5 ntfy/Pushover alerts dropped | ✅ fixed |
+| C6 metrics duplicate HELP/TYPE (+ M2 empty value, df) | ✅ fixed |
+| C7 updater self-update lock deadlock | ✅ fixed |
+| C8 orchestrator interactive-delegation stdin | ✅ fixed |
+| H1/H2/H3 storage cleanup abort / over-delete / dry-run | ✅ fixed |
+| H4 diagnostics `grep -c` arithmetic abort | ✅ fixed |
+| H10 alerts/mic-check JSON escaping | ✅ fixed |
+| MediaMTX v1.19.x support + deprecated-field note | ✅ documented |
+| H5/H6/H8/H9, and MEDIUM/LOW items | ⬜ pending (see below) |
+
+Every ✅ item ships with a regression test; the suite (473 tests) is green and
+now a required CI gate. Remaining items are lower-severity or need real-hardware
+/ live-MediaMTX validation before changing (e.g. the stream-manager supervision
+architecture and the deprecated-JSON-field migration).
+
 ---
 
 ## 2. Test-suite state (before this review)

--- a/docs/ENGINEERING-REVIEW-2026-07.md
+++ b/docs/ENGINEERING-REVIEW-2026-07.md
@@ -1,0 +1,254 @@
+# LyreBirdAudio Engineering Excellence Review — July 2026
+
+Full line-by-line correctness/reliability audit of every script and every test,
+driven by static analysis (`bash -n`, ShellCheck, shfmt, checkbashisms) plus
+deep manual review of all ~22,000 lines of Bash and ~4,500 lines of tests, with
+a current MediaMTX compatibility pass.
+
+**Status legend:** ✅ verified (read + executed) · 🔎 verified by reading ·
+🧪 reproduced empirically · ⬜ fix pending · ✔️ fixed
+
+---
+
+## 1. Executive summary
+
+The suite is thoughtfully engineered in many places (atomic PID/config writes,
+PID-recycle-aware locking, bounded `curl` timeouts, defensive common library).
+However, the review found **multiple independently-verified defects in core
+features**, several of which mean a headline capability silently does not work:
+
+| # | Severity | Component | One-line impact |
+|---|----------|-----------|-----------------|
+| C1 | CRITICAL | usb-audio-mapper | Every generated udev rule is commented out → USB persistent naming never works |
+| C2 | CRITICAL | stream-manager | `wait` under `set -e` kills the wrapper on FFmpeg's first non-zero exit → no auto-restart |
+| C3 | CRITICAL | stream-manager | Wrapper exits when the transient launcher PID dies (`MAIN_SCRIPT_PID=$$`) → no auto-restart |
+| C4 | CRITICAL | mic-check ↔ stream-manager | Device config written mixed-case, read UPPER-case → every per-device setting ignored; `--validate` falsely PASSes |
+| C5 | CRITICAL | lyrebird-alerts | ntfy/Pushover configs silently drop **every** alert and report "sent successfully" |
+| C6 | CRITICAL | lyrebird-metrics | Duplicate `# HELP`/`# TYPE` lines → Prometheus rejects the entire scrape |
+| C7 | CRITICAL | lyrebird-updater | Self-update dead-locks on its own lock after `exec` → self-update always fails |
+| C8 | CRITICAL | lyrebird-orchestrator | Delegated interactive scripts get `stdin=/dev/null` → Quick Setup Wizard can't map devices |
+| C9 | CRITICAL | test suite / CI | bats never runs in CI; 3 test files executed 0 tests; `set -e` leak silently hid failures |
+
+Plus ~15 HIGH and ~20 MEDIUM/LOW findings (below).
+
+### Cross-cutting root cause: `set -euo pipefail` + Bash idioms → silent aborts
+
+Nearly every script sets `set -euo pipefail`. Combined with common Bash idioms
+this produces **silent mid-run aborts** — found independently in four files:
+
+- `wait "$pid"` (non-zero child) → errexit kills the supervisor (stream-manager C2).
+- `((x += y))` returns exit 1 when the result is 0 → errexit aborts the loop
+  (storage cleanup; the same file uses the *safe* `((++count))` elsewhere).
+- `$(… | grep -c PAT || echo 0)` emits `0\n0` → arithmetic syntax error under
+  errexit, or `[[ 0\n0 -gt 0 ]]` noise (diagnostics, metrics).
+- Sourcing a `set -e` script into bats leaks errexit/nounset into the test
+  shell → failing assertions vanish instead of reporting `not ok` (test suite).
+
+This class is the highest-leverage thing to fix and to guard with tests.
+
+---
+
+## 2. Test-suite state (before this review)
+
+CI (`bash-ci.yml`) runs `bash -n`, ShellCheck (`--severity=warning`, the only
+gate), shfmt, bashate, and a grep security scan — but **never runs the bats
+tests**. Running them locally revealed:
+
+- **3 files executed 0 of their tests** (`test_install_mediamtx` 0/60,
+  `test_lyrebird_storage` 0/48, `test_lyrebird_updater` 0/51 = **159 hidden
+  tests**) because those scripts ended with a bare `main "$@"`; bats' `source`
+  ran `main`, which called `exit`, aborting the file. ✔️ Fixed: added a
+  `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` guard to all 7 unguarded scripts.
+- After the guard, several files still under-executed because the sourced
+  script's `set -euo pipefail` leaked into the bats shell and turned failing
+  assertions / unset-var reads into silent aborts. ✔️ Being fixed by restoring
+  bats' error handling (`set +euo pipefail`) in each affected `setup()`.
+- Genuine stale-test bugs surfaced: e.g. storage/updater tests assert
+  `$SCRIPT_VERSION` but the scripts define `VERSION`; installer tests assert
+  `$PLATFORM`/`DRY_RUN`/`version_compare`-prints-to-stdout against an API the
+  2.0.1 script no longer has.
+- ShellCheck at `--severity=warning` is clean; at style level only 3 style + a
+  batch of `SC2317` (unreachable — false positives from dispatch/trap) remain.
+
+---
+
+## 3. CRITICAL findings
+
+### C1 — usb-audio-mapper: udev rules are emitted as a comment 🧪⬜
+`usb-audio-mapper.sh:625` builds the comment with a **literal** `\n`
+(`"# USB Sound Card: …\n"` — Bash does not expand `\n` in double quotes), and
+`:645`/`:686` print it with `printf '%s'` (no escape processing). Comment and
+rule collapse onto **one `#`-prefixed physical line**, so udev ignores the whole
+rule. Verified by running the real function: `grep -vc '^#'` = **0** active
+rules. `ATTR{id}` is never set → `/dev/snd/by-id/<name>` never created → devices
+are not persistently named across reboot. Present since 2025-09-03. The mapper
+still prints "Rules written successfully".
+**Fix:** emit a real newline (`printf '# USB Sound Card: %s\n%s\n' …`).
+
+### C2 — stream-manager: bare `wait` under `set -e` defeats restart 🔎⬜
+Generated wrapper runs `set -euo pipefail` (`:3733`, `:3300`); the restart loop
+does a bare `wait "${FFMPEG_PID}" 2>/dev/null` (`:4003`, `:3601`) before
+`exit_code=$?`. FFmpeg exits non-zero on essentially every real failure (USB
+glitch, MediaMTX blip, signal) → errexit kills the wrapper before the
+exponential-backoff/restart code runs. The self-healing engine is dead on every
+failure path.
+**Fix:** `local ec=0; wait "${FFMPEG_PID}" 2>/dev/null || ec=$?` (do **not** use
+`|| true` — the code needs the code).
+
+### C3 — stream-manager: wrapper tied to transient launcher PID 🔎⬜
+`MAIN_SCRIPT_PID="$$"` (`:3761`, `:3341`) captures the `start` process PID at
+generation time; wrappers are launched `nohup setsid bash wrapper &` (`:3660`)
+and `start` then returns/exits (systemd `Type=forking`). `check_parent_alive`
+(`:3941`, called `:3958`/`:4034`) then sees the launcher dead and `break`s — so
+even with C2 fixed, the wrapper exits instead of restarting.
+**Fix:** drop the `check_parent_alive` gating (the `CLEANUP_MARKER` check already
+handles graceful stop), or monitor the MediaMTX PID instead.
+
+### C4 — mic-check ↔ stream-manager: device-config key case mismatch ✅⬜
+`generate_config` writes `DEVICE_${safe_name}_…` case-preserving
+(`mic-check:421`, `:1777`), but `get_device_config` reads
+`DEVICE_${name^^}_…` upper-cased (`stream-manager:3062`, `:3073`). For any
+device id not already all-caps (`Yeti`, `Blue Yeti`, `Device`), **every**
+generated setting (sample rate, channels, bitrate, codec) is dropped and
+defaults are used. `mic-check --validate` still reports PASS (it checks its own
+mixed-case names). A "high quality / 192 kHz" mic silently streams at 48000/2/128k.
+**Fix:** upper-case the emitted names in `generate_config`/`validate_config`.
+
+### C5 — lyrebird-alerts: ntfy/Pushover silently drop every alert 🔎⬜
+`send_alert` early-returns 0 unless `LYREBIRD_WEBHOOK_URL(_S)` is set (`:614`),
+but the ntfy/Pushover setup paths never populate it (`:958`), so no alert is
+ever sent — and `cmd_test`/setup print "Test alert sent successfully!" (`:1026`,
+`:1083`) because the guard returned 0. Two of five documented webhook types are
+fully non-functional and fail silently *with a success message*.
+**Fix:** make the "destination configured?" check type-aware; distinguish
+"skipped, nothing sent" from real delivery in `cmd_test`.
+
+### C6 — lyrebird-metrics: duplicate HELP/TYPE breaks the whole scrape 🧪⬜
+`emit_metric` prints `# HELP`/`# TYPE` on every call; it is called in loops for
+the same metric family (disk over `/`,`/var`,`/tmp` at `:237`; per-stream at
+`:454`/`:462`/`:470`). The Prometheus text format allows one HELP/TYPE per
+family; the reference parser rejects the **entire** response, so the target
+shows DOWN. Happens on every host, every scrape.
+**Fix:** emit HELP/TYPE once per family, before the loop.
+
+### C7 — lyrebird-updater: self-update dead-locks on its own lock 🧪⬜
+Self-update `exec`s the new script without releasing the lock first (`:2088`);
+the re-exec'd process has the same PID, sees the lock "held" by that PID, the
+PID-recycle staleness check doesn't fire (it *is* that PID), it waits
+`LOCK_MAX_WAIT` and exits `E_LOCKED`. `--post-update-restore` never runs; the
+stash and service-update marker are orphaned. Reproduced by the reviewer.
+**Fix:** `release_lock` immediately before the `exec`.
+
+### C8 — orchestrator: interactive delegations get stdin=/dev/null 🔎⬜
+`execute_script` runs children as `"${script_path}" "${args[@]}" &` then `wait`
+(`:691`, `:713`, `:743`). With job control off (a script), a backgrounded
+command's stdin is redirected from `/dev/null`, so interactive children (USB
+mapper `read`, updater menu) read EOF. Quick Setup Wizard Step 2 (device
+mapping), USB menu option 1, and "Launch Update Manager" cannot receive input;
+"Uninstall" hits EOF on its confirm *after* removing the binary.
+**Fix:** run interactive delegations in the foreground, or append `</dev/tty`.
+
+### C9 — CI never runs the tests; test rot invisible ✅✔️/⬜
+See §2. Guards added; harness stabilization + a CI bats job pending.
+
+---
+
+## 4. HIGH findings
+
+- **H1 storage — cleanup aborts on a 0-byte file** 🧪 `((freed_bytes += size))`
+  (`:230`,`:253`,`:264`,`:284`,`:294`) returns exit 1 when the sum is 0; under
+  `set -e` the first 0-byte `.wav` halts cleanup → disk fills on a 24/7 recorder.
+  **Fix:** `freed_bytes=$((freed_bytes + size))`.
+- **H2 storage — emergency deletes all `/var/log/*.gz`** 🔎 `MEDIAMTX_LOG_DIR`
+  resolves to `/var/log`; `find "$MEDIAMTX_LOG_DIR" -name "*.gz" -delete`
+  (`:362-363`, plus `*.tmp` at `:306`) wipes unrelated system logs during an
+  incident. **Fix:** scope to `-maxdepth 1 -name 'mediamtx*.out*.gz'`.
+- **H3 storage — `--dry-run emergency` actually deletes** 🔎 `find -delete`/`rm -rf`
+  in `emergency_cleanup` (`:362-370`) bypass `DRY_RUN`. **Fix:** gate on `DRY_RUN`.
+- **H4 diagnostics — `debug` aborts on a healthy system** 🧪
+  `$(( $(… grep -ic error || echo 0) ))` (`:2159`,`:2161`) receives `0\n0` →
+  arithmetic syntax error → `set -e` kills the run mid-diagnostic. **Fix:** drop
+  the redundant `|| echo 0`.
+- **H5 updater — branch switch never fast-forwards** 🔎 `git checkout <branch>`
+  (`:2007`) lands on the stale local tip; "Switch to Development" no-ops while
+  reporting success. **Fix:** `git merge --ff-only origin/<branch>` for branch targets.
+- **H6 updater — `update -V <ver>` overridden to latest** 🔎 built-in `--upgrade`
+  path (`install_mediamtx.sh:1300-1323`) ignores the pinned target and only
+  checks `new != current`. **Fix:** only use `--upgrade` when target == latest;
+  verify `new == RELEASE_VERSION`.
+- **H7 usb-mapper — udev rule injection via unsanitized name** 🧪
+  `tr -cd '[:alnum:] \t-_.'` (`:622`) parses `\t-_` as the range 0x09–0x5F,
+  permitting `"`, `$`, `;`, `=`, newline; `device_name` (`-d`) is unvalidated
+  (`:929`) → an embedded newline yields an active root `RUN+=` line. **Fix:**
+  `tr -cd '[:alnum:] ._-'` + strip newlines; validate `device_name`.
+- **H8 stream-manager — no resurrection of a dead stream** 🔎 cron `monitor` is
+  report-only (`CRON=1` ⇒ `allow_restart=false`, exit 10); only
+  `E_CRITICAL_RESOURCE` triggers a full-service restart. With C2/C3, a dead
+  stream stays down forever. **Fix:** give cron a bounded per-stream restart path.
+- **H9 stream-manager — health check only verifies the bash PID** 🔎
+  `monitor_streams` (`:2535`,`:2622`) checks the wrapper process exists, never
+  MediaMTX `ready:true` or an FFmpeg child → a mid-backoff/silent-mic stream
+  reports healthy. **Fix:** also query `/v3/paths/get/<name>`.
+- **H10 alerts/mic-check — invalid JSON drops webhooks** 🧪 `json_escape`
+  (`alerts:342`) misses control chars (`\b`,`\f`,ESC,0x00–0x1F); mic-check
+  `output_json` (`:2261`) escapes `"` but not `\` first → a device name with `\`
+  or an ANSI code produces invalid JSON → webhook 400 / `jq` failure. **Fix:**
+  escape `\` first, then `"`, then control chars (or shell to `jq -Rs .`).
+
+---
+
+## 5. MEDIUM / LOW findings (abridged register)
+
+metrics: empty `stream_cpu_percent` value (`:469`), bare `0` line from
+`grep -c … || echo 0` (`:180`), pagination `itemCount` ignored (`:331`+), label
+values unescaped (`:453`). storage: `df|tail -1` misparses wrapped device names
+(`:169`/`:175`) → full disk read as OK; timeout clamp before config load; ntfy
+colon-in-title truncation (`:536`); rate-limit TOCTOU. common: spinner leaks an
+orphan process / hides cursor with no EXIT trap (`:568-624`); `run_with_timeout`
+swallows stderr. diagnostics: `is_device_busy`/`hw_params` sentinel `closed`
+mis-read; `df` not POSIX (`:1020`); inotify %="watches vs instances" (`:1338`);
+`nc -zv` BusyBox; long-uptime false "recent crash" (`:2558`); `^64` perms accepts
+646/647 (`:2443`). mic-check: `low` tier emits unsupported channel count
+(`:1226`); `restore_config_backup` doesn't back up current first. usb-mapper:
+synthetic `busX-devY` → dead `KERNELS` rule; cross-fs `mv` not atomic (`:696`);
+VID:PID-only rule renames all identical mics; `SYMLINK+=` on whole `sound`
+subsystem (no `KERNEL==` gate). orchestrator: in-session update trips the
+integrity check (`:647`); announces `/dev/snd/by-usb-port/` that nothing creates
+(`:951`,`:1234`); Quick Setup not idempotent (installer exit 7 fatal); diagnostics
+export bypasses integrity check (`:1676`). install: GNU-only `-printf`/`head -n -3`
+backup prune no-ops on BSD; INT/TERM handler `return`s and gates rollback on `$?`;
+`flock`+unlink race in `release_lock`.
+
+---
+
+## 6. MediaMTX modernization (current latest: v1.19.2, 2026-06-28)
+
+- API prefix still `/v3/`; **all endpoints the suite uses remain valid.** Asset
+  naming and `checksums.sha256` unchanged. Dynamic version fetch means no
+  hardcoded-version breakage.
+- **Good news:** the suite emits **no** removed config keys (`fallback`,
+  `authJWTInHTTPQuery`) — verified. (MediaMTX ≥1.16 refuses to start on unknown
+  keys, so this would have been fatal.)
+- **To modernize:** bump the supported/target string to v1.19.x; the JSON status
+  fields parsed by grep (`"ready":true` in stream-manager ×4 + metrics ×1) are
+  now *deprecated* (still returned) in favour of `available`/`online`/
+  `inboundBytes`/`outboundBytes`/`tracks2` — migrate before a future major drop.
+  Consider `/v3/info` for a light version/health probe.
+
+---
+
+## 7. Remediation plan (priority order)
+
+1. **Test harness + CI** (safety net): source guards ✔️, `set +e` in affected
+   setups, fix stale-test bugs, add a bats CI job, keep ShellCheck gate.
+2. **CRITICALs** C1–C8, each with a regression test that fails before / passes after.
+3. **HIGH** H1–H10 with tests.
+4. **MEDIUM/LOW** as capacity allows.
+5. **MediaMTX** version bump + tolerant status parsing.
+6. **Hardware-free E2E harness**: PATH-shim fakes for `ffmpeg`, `arecord`,
+   `lsusb`, `udevadm`, `systemctl`, and a stub MediaMTX HTTP API, driving
+   install→map→configure→stream→monitor→alert with no real hardware.
+7. Docs/CHANGELOG updates.
+
+Every fix is verified against the actual code; line numbers are from the state
+at review time and may shift as fixes land.

--- a/install_mediamtx.sh
+++ b/install_mediamtx.sh
@@ -1937,4 +1937,7 @@ main() {
     log_debug "Operation completed successfully"
 }
 
-main "$@"
+# Only execute when run directly, not when sourced (e.g. by the test suite)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/lyrebird-alerts.sh
+++ b/lyrebird-alerts.sh
@@ -341,11 +341,30 @@ cleanup_state() {
 # Escape a string for safe JSON embedding
 json_escape() {
     local s="$1"
-    s="${s//\\/\\\\}"
+    s="${s//\\/\\\\}"       # backslash first, or later escapes double-escape
     s="${s//\"/\\\"}"
     s="${s//$'\n'/\\n}"
     s="${s//$'\r'/\\r}"
     s="${s//$'\t'/\\t}"
+    s="${s//$'\b'/\\b}"
+    s="${s//$'\f'/\\f}"
+    # Escape any remaining control characters (U+0001..U+001F -- e.g. ESC 0x1B
+    # from ANSI/ffmpeg output pasted into a reason) as \u00XX per RFC 8259.
+    # Without this, a control byte yields invalid JSON and the webhook (Discord/
+    # Slack) rejects it with HTTP 400, silently dropping the alert.
+    if [[ "$s" == *[$'\x01'-$'\x1f']* ]]; then
+        local i c cc out=""
+        for ((i = 0; i < ${#s}; i++)); do
+            c="${s:i:1}"
+            if [[ "$c" == [$'\x01'-$'\x1f'] ]]; then
+                printf -v cc '\\u%04x' "'$c"
+                out+="$cc"
+            else
+                out+="$c"
+            fi
+        done
+        s="$out"
+    fi
     printf '%s' "$s"
 }
 

--- a/lyrebird-alerts.sh
+++ b/lyrebird-alerts.sh
@@ -590,6 +590,23 @@ send_webhook() {
 # Main Alert Function
 #=============================================================================
 
+# Return 0 if at least one alert destination is configured, else 1.
+# Type-aware: ntfy needs a topic, Pushover needs token+user, others need a URL.
+# (ntfy/Pushover build their endpoint from their own vars, not LYREBIRD_WEBHOOK_URL.)
+alert_destination_configured() {
+    [[ -n "${LYREBIRD_WEBHOOK_URL:-}" ]] && return 0
+    [[ -n "${LYREBIRD_WEBHOOK_URLS:-}" ]] && return 0
+    case "${LYREBIRD_WEBHOOK_TYPE:-generic}" in
+        ntfy)
+            [[ -n "${LYREBIRD_NTFY_TOPIC:-}" ]] && return 0
+            ;;
+        pushover)
+            [[ -n "${LYREBIRD_PUSHOVER_TOKEN:-}" && -n "${LYREBIRD_PUSHOVER_USER:-}" ]] && return 0
+            ;;
+    esac
+    return 1
+}
+
 # Send an alert
 # Usage: send_alert <level> <title> <message> [alert_type]
 send_alert() {
@@ -610,9 +627,11 @@ send_alert() {
         return 0
     fi
 
-    # Check if webhook URL is configured
-    if [[ -z "${LYREBIRD_WEBHOOK_URL}" ]] && [[ -z "${LYREBIRD_WEBHOOK_URLS}" ]]; then
-        log_debug "No webhook URL configured, skipping alert"
+    # Check that at least one destination is configured (type-aware). ntfy and
+    # Pushover do NOT use LYREBIRD_WEBHOOK_URL, so keying only off the URL here
+    # silently dropped every ntfy/Pushover alert (and cmd_test reported success).
+    if ! alert_destination_configured; then
+        log_debug "No alert destination configured, skipping alert"
         return 0
     fi
 
@@ -630,11 +649,24 @@ send_alert() {
     # Log the alert
     log_alert "$level" "${message}"
 
-    # Build list of webhooks to send to
+    # Build list of webhooks to send to. ntfy/Pushover get an entry from their own
+    # config vars even when LYREBIRD_WEBHOOK_URL is empty -- send_webhook builds
+    # the real endpoint for those types, so the URL field here is unused for them.
     local webhooks=()
-    if [[ -n "${LYREBIRD_WEBHOOK_URL}" ]]; then
-        webhooks+=("${LYREBIRD_WEBHOOK_URL}:${LYREBIRD_WEBHOOK_TYPE}")
-    fi
+    case "${LYREBIRD_WEBHOOK_TYPE}" in
+        ntfy)
+            [[ -n "${LYREBIRD_NTFY_TOPIC}" ]] \
+                && webhooks+=("${LYREBIRD_NTFY_SERVER}/${LYREBIRD_NTFY_TOPIC}:ntfy")
+            ;;
+        pushover)
+            [[ -n "${LYREBIRD_PUSHOVER_TOKEN}" && -n "${LYREBIRD_PUSHOVER_USER}" ]] \
+                && webhooks+=("pushover-api:pushover")
+            ;;
+        *)
+            [[ -n "${LYREBIRD_WEBHOOK_URL}" ]] \
+                && webhooks+=("${LYREBIRD_WEBHOOK_URL}:${LYREBIRD_WEBHOOK_TYPE}")
+            ;;
+    esac
 
     # Add additional webhooks
     if [[ -n "${LYREBIRD_WEBHOOK_URLS}" ]]; then
@@ -1076,6 +1108,15 @@ cmd_test() {
 
     # Force enable for test (no need to save/restore - script exits after test)
     LYREBIRD_ALERT_ENABLED="true"
+
+    # Don't claim success if nothing is configured -- send_alert would return 0
+    # (skipped) and we'd falsely report the test as delivered.
+    if ! alert_destination_configured; then
+        echo "No alert destination is configured."
+        echo "Set a webhook URL, or an ntfy topic, or a Pushover token+user"
+        echo "(run '${SCRIPT_NAME}.sh setup'), then re-run the test."
+        return 1
+    fi
 
     if send_alert "info" "Test Alert from LyreBirdAudio" \
         "This is a test alert from ${LYREBIRD_HOSTNAME}. If you received this, alerts are working!" \

--- a/lyrebird-diagnostics.sh
+++ b/lyrebird-diagnostics.sh
@@ -867,9 +867,9 @@ get_recent_log_warnings() {
     since_time=$(get_relative_date "-24H" 2>/dev/null || echo "")
 
     if [[ -z "${since_time}" ]]; then
-        warning_count=$(tail -n 2000 "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "warn\|error" || echo 0)
+        warning_count=$(tail -n 2000 "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "warn\|error" || true)
     else
-        warning_count=$(grep "${since_time%% *}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "warn\|error" || echo 0)
+        warning_count=$(grep "${since_time%% *}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "warn\|error" || true)
     fi
 
     echo "${warning_count}"
@@ -1452,7 +1452,7 @@ validate_device_config_consistency() {
     local referenced_devices=0
 
     if is_readable "${config_file}"; then
-        referenced_devices=$(grep -c "source:\|input:" "${config_file}" 2>/dev/null || echo 0)
+        referenced_devices=$(grep -c "source:\|input:" "${config_file}" 2>/dev/null || true)
 
         if [[ ! -f "${MEDIAMTX_DEVICE_CONFIG}" ]] || ! is_readable "${MEDIAMTX_DEVICE_CONFIG}"; then
             echo "config_unreadable"
@@ -1460,7 +1460,7 @@ validate_device_config_consistency() {
         fi
 
         local available_devices
-        available_devices=$(grep -c "^[^ ].*:" "${MEDIAMTX_DEVICE_CONFIG}" 2>/dev/null || echo 0)
+        available_devices=$(grep -c "^[^ ].*:" "${MEDIAMTX_DEVICE_CONFIG}" 2>/dev/null || true)
 
         if ((referenced_devices > available_devices)); then
             echo "mismatch"
@@ -2034,7 +2034,7 @@ check_stream_health() {
 
     if [[ -f "${MEDIAMTX_LOG_FILE}" ]] && is_readable "${MEDIAMTX_LOG_FILE}"; then
         local error_count
-        error_count=$(($(tail -n "${DIAGNOSTIC_LOG_TAIL_LINES}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "error\|fail") + 0))
+        error_count=$(($(tail -n "${DIAGNOSTIC_LOG_TAIL_LINES}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "error\|fail" || true) + 0))
 
         if [[ "${error_count}" -gt 10 ]]; then
             print_status "Recent Errors" "WARN" "Found ${error_count} errors in recent logs"
@@ -2156,9 +2156,13 @@ check_log_analysis() {
     print_status "Log Size" "INFO" "Total lines: ${total_lines}"
 
     local error_lines
-    error_lines=$(($(tail -n "${DIAGNOSTIC_LOG_TAIL_LINES}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "error" || echo 0)))
+    # NOTE: `grep -ic` already prints "0" on no match (and exits 1). The old
+    # `|| echo 0` appended a SECOND "0", so $(( "0\n0" )) was an arithmetic syntax
+    # error that, under set -euo pipefail, aborted the whole diagnostic on a quiet
+    # (healthy) system. Match the safe `+ 0` form used elsewhere in this file.
+    error_lines=$(($(tail -n "${DIAGNOSTIC_LOG_TAIL_LINES}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "error" || true) + 0))
     local warn_lines
-    warn_lines=$(($(tail -n "${DIAGNOSTIC_LOG_TAIL_LINES}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "warn" || echo 0)))
+    warn_lines=$(($(tail -n "${DIAGNOSTIC_LOG_TAIL_LINES}" "${MEDIAMTX_LOG_FILE}" 2>/dev/null | grep -ic "warn" || true) + 0))
 
     if [[ "${error_lines}" -gt 0 ]]; then
         print_status "Error Patterns" "WARN" "Found ${error_lines} error line(s)"

--- a/lyrebird-diagnostics.sh
+++ b/lyrebird-diagnostics.sh
@@ -3239,4 +3239,7 @@ main() {
     return "${EXIT_CODE}"
 }
 
-main "$@"
+# Only execute when run directly, not when sourced (e.g. by the test suite)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/lyrebird-metrics.sh
+++ b/lyrebird-metrics.sh
@@ -88,6 +88,18 @@ emit_metric() {
     fi
 }
 
+# Emit ONLY the HELP/TYPE header lines for a metric family. Prometheus requires
+# exactly one HELP and one TYPE per family; for metrics produced in a loop (one
+# sample per disk/stream) the header must be printed once, before the samples,
+# with each per-sample emit_metric call passing an empty help argument.
+emit_help_type() {
+    local name="$1"
+    local help="$2"
+    local type="${3:-gauge}"
+    echo "# HELP ${METRIC_PREFIX}_${name} ${help}"
+    echo "# TYPE ${METRIC_PREFIX}_${name} ${type}"
+}
+
 # Collect MediaMTX service metrics
 collect_mediamtx_metrics() {
     local mediamtx_running=0
@@ -227,14 +239,22 @@ collect_usb_audio_metrics() {
 
 # Collect system resource metrics
 collect_system_metrics() {
-    # Disk usage for relevant paths
+    # Disk usage for relevant paths. HELP/TYPE for the disk_usage_percent family
+    # must appear exactly once (not once per path) or Prometheus rejects the whole
+    # scrape. df -P forces single-line POSIX output; a wrapped long device name
+    # (LVM/dm/ZFS) would otherwise shift columns and yield a non-numeric percent.
+    local _disk_hdr=0
     for path in "/" "/var" "/tmp"; do
         if [[ -d "$path" ]] && has_command df; then
             local usage
-            usage=$(df "$path" 2>/dev/null | tail -1 | awk '{print $5}' | sed 's/%//')
+            usage=$(df -P "$path" 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')
             if [[ "$usage" =~ ^[0-9]+$ ]]; then
+                if [[ $_disk_hdr -eq 0 ]]; then
+                    emit_help_type "disk_usage_percent" "Disk usage percentage" "gauge"
+                    _disk_hdr=1
+                fi
                 local label="mount=\"${path}\""
-                emit_metric "disk_usage_percent" "$usage" "Disk usage percentage" "gauge" "$label"
+                emit_metric "disk_usage_percent" "$usage" "" "gauge" "$label"
             fi
         fi
     done
@@ -436,6 +456,7 @@ collect_stream_metrics() {
         return
     fi
 
+    local _stream_hdr=0
     for pid_file in "${FFMPEG_PID_DIR}"/*.pid; do
         [[ -f "$pid_file" ]] || continue
 
@@ -444,6 +465,14 @@ collect_stream_metrics() {
         local pid
         pid=$(cat "$pid_file" 2>/dev/null)
 
+        # Emit HELP/TYPE for the per-stream families exactly once, before samples.
+        if [[ $_stream_hdr -eq 0 ]]; then
+            emit_help_type "stream_up" "Stream running status" "gauge"
+            emit_help_type "stream_memory_bytes" "Stream memory usage in bytes" "gauge"
+            emit_help_type "stream_cpu_percent" "Stream CPU usage percentage" "gauge"
+            _stream_hdr=1
+        fi
+
         # Stream status
         local status=0
         if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
@@ -451,7 +480,7 @@ collect_stream_metrics() {
         fi
 
         local labels="stream=\"${stream_name}\""
-        emit_metric "stream_up" "$status" "Stream running status" "gauge" "$labels"
+        emit_metric "stream_up" "$status" "" "gauge" "$labels"
 
         if [[ $status -eq 1 ]] && [[ -d "/proc/${pid}" ]]; then
             # Stream memory usage
@@ -459,15 +488,17 @@ collect_stream_metrics() {
                 local vm_rss
                 vm_rss=$(grep "^VmRSS:" "/proc/${pid}/status" 2>/dev/null | awk '{print $2}' || echo 0)
                 if [[ "$vm_rss" =~ ^[0-9]+$ ]]; then
-                    emit_metric "stream_memory_bytes" "$((vm_rss * 1024))" "Stream memory usage" "gauge" "$labels"
+                    emit_metric "stream_memory_bytes" "$((vm_rss * 1024))" "" "gauge" "$labels"
                 fi
             fi
 
-            # Stream CPU usage
+            # Stream CPU usage. ps may print nothing if the process just exited;
+            # default to 0 so we never emit a metric line with an empty value.
             if has_command ps; then
                 local cpu
-                cpu=$(ps -p "$pid" -o %cpu= 2>/dev/null | tr -d ' ' || echo 0)
-                emit_metric "stream_cpu_percent" "${cpu%.*}" "Stream CPU usage" "gauge" "$labels"
+                cpu=$(ps -p "$pid" -o %cpu= 2>/dev/null | tr -d ' ')
+                cpu="${cpu:-0}"
+                emit_metric "stream_cpu_percent" "${cpu%.*}" "" "gauge" "$labels"
             fi
         fi
     done

--- a/lyrebird-metrics.sh
+++ b/lyrebird-metrics.sh
@@ -309,7 +309,7 @@ api_call_with_retry() {
 }
 
 # Collect MediaMTX API metrics (if available)
-# Enhanced in v1.1.0 with full MediaMTX v1.15.5 API coverage
+# Enhanced in v1.1.0 with MediaMTX /v3 API coverage (validated v1.15.5 - v1.19.x)
 collect_api_metrics() {
     if ! has_command curl; then
         return

--- a/lyrebird-metrics.sh
+++ b/lyrebird-metrics.sh
@@ -647,4 +647,7 @@ main() {
     esac
 }
 
-main "$@"
+# Only execute when run directly, not when sourced (e.g. by the test suite)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/lyrebird-mic-check.sh
+++ b/lyrebird-mic-check.sh
@@ -2262,8 +2262,14 @@ output_json() {
         fi
 
         if [[ "$in_device" = true ]]; then
-            # Escape quotes in value
+            # Escape for JSON: backslash FIRST (else a trailing '\' escapes the
+            # closing quote and produces invalid JSON), then quotes and the
+            # common control characters.
+            value="${value//\\/\\\\}"
             value="${value//\"/\\\"}"
+            value="${value//$'\n'/\\n}"
+            value="${value//$'\r'/\\r}"
+            value="${value//$'\t'/\\t}"
 
             # Determine if value is numeric, boolean, or string
             if [[ "$value" =~ ^[0-9]+$ ]]; then

--- a/lyrebird-mic-check.sh
+++ b/lyrebird-mic-check.sh
@@ -1678,13 +1678,16 @@ generate_config() {
 #   DEVICE_<sanitized_name>_<PARAMETER>=value
 #
 # Where:
-#   - <sanitized_name> is the device name with special chars replaced by underscore
+#   - <sanitized_name> is the device name with special chars replaced by
+#     underscore and then UPPERCASED, so the key matches the exact lookup the
+#     stream manager performs (DEVICE_${name^^}_${param^^}). A case mismatch
+#     here silently drops every per-device setting.
 #   - <PARAMETER> is one of: SAMPLE_RATE, CHANNELS, BITRATE
 #
-# Example:
-#   DEVICE_Blue_Yeti_SAMPLE_RATE=48000
-#   DEVICE_Blue_Yeti_CHANNELS=2
-#   DEVICE_Blue_Yeti_BITRATE=192k
+# Example (device "Blue Yeti"):
+#   DEVICE_BLUE_YETI_SAMPLE_RATE=48000
+#   DEVICE_BLUE_YETI_CHANNELS=2
+#   DEVICE_BLUE_YETI_BITRATE=192k
 #
 # Fallback Defaults (used when device-specific config not found):
 
@@ -1774,9 +1777,9 @@ EOF
 #   Channels: ${PARSED_CAPS[channels]:-unknown}
 #   Formats: ${PARSED_CAPS[formats]:-unknown}
 # Selected settings (quality tier: $QUALITY_TIER):
-DEVICE_${safe_name}_SAMPLE_RATE=$optimal_rate
-DEVICE_${safe_name}_CHANNELS=$optimal_channels
-DEVICE_${safe_name}_BITRATE=${enc_bitrate}k
+DEVICE_${safe_name^^}_SAMPLE_RATE=$optimal_rate
+DEVICE_${safe_name^^}_CHANNELS=$optimal_channels
+DEVICE_${safe_name^^}_BITRATE=${enc_bitrate}k
 
 EOF
 
@@ -1860,8 +1863,10 @@ get_config_value() {
     local device_id_safe="$2"
     local param="$3"
 
-    # Try friendly name first
-    local var_name="DEVICE_${safe_name}_${param}"
+    # Try friendly name first. Keys are UPPERCASED to match the exact lookup the
+    # stream manager performs (DEVICE_${name^^}_${param^^}); a case mismatch here
+    # silently drops every generated per-device setting.
+    local var_name="DEVICE_${safe_name^^}_${param^^}"
     if [[ -n "${!var_name:-}" ]]; then
         echo "${!var_name}"
         return 0
@@ -1869,7 +1874,7 @@ get_config_value() {
 
     # Try full device ID if provided
     if [[ -n "$device_id_safe" ]]; then
-        var_name="DEVICE_${device_id_safe}_${param}"
+        var_name="DEVICE_${device_id_safe^^}_${param^^}"
         if [[ -n "${!var_name:-}" ]]; then
             echo "${!var_name}"
             return 0

--- a/lyrebird-orchestrator.sh
+++ b/lyrebird-orchestrator.sh
@@ -688,7 +688,7 @@ execute_script() {
             PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
             LOGNAME="$SUDO_USER" \
             USER="$SUDO_USER" \
-            "${script_path}" "${args[@]}" &
+            "${script_path}" "${args[@]}" </dev/tty &
 
         CHILD_PID=$!
 
@@ -710,7 +710,7 @@ execute_script() {
     # Diagnostics uses exit codes: 0=success, 1=warnings, 2=failures
     # We should NOT show error messages for warnings (exit code 1)
     if [[ "$script_key" == "diagnostics" ]]; then
-        "${script_path}" "${args[@]}" &
+        "${script_path}" "${args[@]}" </dev/tty &
         CHILD_PID=$!
 
         local exit_code=0
@@ -739,8 +739,12 @@ execute_script() {
         esac
     fi
 
-    # All other scripts execute as root with child process tracking
-    "${script_path}" "${args[@]}" &
+    # All other scripts execute as root with child process tracking.
+    # `</dev/tty` gives the child the controlling terminal: a backgrounded
+    # command (needed here for CHILD_PID signal tracking) otherwise has its stdin
+    # redirected from /dev/null, so interactive delegations (USB mapper, updater
+    # menu, uninstall confirmation) read EOF and abort instead of prompting.
+    "${script_path}" "${args[@]}" </dev/tty &
     CHILD_PID=$!
 
     local exit_code=0

--- a/lyrebird-orchestrator.sh
+++ b/lyrebird-orchestrator.sh
@@ -2045,4 +2045,7 @@ main() {
 }
 
 # Run main function
-main "$@"
+# Only execute when run directly, not when sourced (e.g. by the test suite)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/lyrebird-storage.sh
+++ b/lyrebird-storage.sh
@@ -581,4 +581,7 @@ main() {
     esac
 }
 
-main "$@"
+# Only execute when run directly, not when sourced (e.g. by the test suite)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/lyrebird-storage.sh
+++ b/lyrebird-storage.sh
@@ -227,7 +227,7 @@ cleanup_recordings() {
         size=$(stat -c%s "$file" 2>/dev/null || echo 0)
         safe_delete "$file" "recording"
         ((++count))
-        ((freed_bytes += size))
+        freed_bytes=$((freed_bytes + size))
     done < <(find "$RECORDING_DIR" -type f \( -name "*.wav" -o -name "*.mp3" -o -name "*.flac" -o -name "*.opus" -o -name "*.ogg" \) -mtime "+${RECORDING_RETENTION_DAYS}" -print0 2>/dev/null)
 
     # Remove empty directories
@@ -250,7 +250,7 @@ cleanup_logs() {
             size=$(stat -c%s "$file" 2>/dev/null || echo 0)
             safe_delete "$file" "log"
             ((++count))
-            ((freed_bytes += size))
+            freed_bytes=$((freed_bytes + size))
         done < <(find "$LOG_DIR" -type f -name "*.log*" -mtime "+${LOG_RETENTION_DAYS}" -print0 2>/dev/null)
     fi
 
@@ -261,7 +261,7 @@ cleanup_logs() {
             size=$(stat -c%s "$file" 2>/dev/null || echo 0)
             safe_delete "$file" "mediamtx log"
             ((++count))
-            ((freed_bytes += size))
+            freed_bytes=$((freed_bytes + size))
         done < <(find "$MEDIAMTX_LOG_DIR" -type f -name "mediamtx*.out.*" -mtime "+${LOG_RETENTION_DAYS}" -print0 2>/dev/null)
     fi
 
@@ -281,7 +281,7 @@ cleanup_temp() {
         size=$(stat -c%s "$file" 2>/dev/null || echo 0)
         safe_delete "$file" "temp"
         ((++count))
-        ((freed_bytes += size))
+        freed_bytes=$((freed_bytes + size))
     done < <(find "$TEMP_DIR" -maxdepth 1 -type f -name "lyrebird-*" -mmin "+$((TEMP_RETENTION_HOURS * 60))" -print0 2>/dev/null)
 
     # Clean memory buffer directory if present
@@ -291,7 +291,7 @@ cleanup_temp() {
             size=$(stat -c%s "$file" 2>/dev/null || echo 0)
             safe_delete "$file" "buffer"
             ((++count))
-            ((freed_bytes += size))
+            freed_bytes=$((freed_bytes + size))
         done < <(find "$BUFFER_DIR" -type f -mmin "+$((TEMP_RETENTION_HOURS * 60))" -print0 2>/dev/null)
     fi
 
@@ -302,9 +302,11 @@ cleanup_temp() {
 truncate_large_logs() {
     log_info "Checking for oversized log files"
 
-    # Clean up any stale .tmp files from interrupted previous runs
-    find "$MEDIAMTX_LOG_DIR" -name "*.tmp" -mmin +5 -delete 2>/dev/null || true
-    [[ -d "$LOG_DIR" ]] && find "$LOG_DIR" -name "*.tmp" -mmin +5 -delete 2>/dev/null || true
+    # Clean up any stale .tmp files from interrupted previous runs.
+    # MEDIAMTX_LOG_DIR is typically /var/log, so scope tightly to our own files
+    # (maxdepth 1 + mediamtx-prefixed) rather than every *.tmp on the system.
+    find "$MEDIAMTX_LOG_DIR" -maxdepth 1 -name "mediamtx*.tmp" -mmin +5 -delete 2>/dev/null || true
+    [[ -d "$LOG_DIR" ]] && find "$LOG_DIR" -maxdepth 1 -name "*.tmp" -mmin +5 -delete 2>/dev/null || true
 
     # Check MediaMTX log
     if [[ -f "$MEDIAMTX_LOG" ]]; then
@@ -358,16 +360,24 @@ emergency_cleanup() {
         log_info "Emergency: Deleted $deleted oldest recording(s)"
     fi
 
-    # Delete all rotated logs
-    find "$LOG_DIR" -name "*.gz" -delete 2>/dev/null || true
-    find "$MEDIAMTX_LOG_DIR" -name "*.gz" -delete 2>/dev/null || true
+    # Delete rotated logs, temp files, and buffer contents.
+    # These must honour DRY_RUN (a "preview" must not delete anything), and the
+    # *.gz sweep must be tightly scoped: MEDIAMTX_LOG_DIR is typically /var/log,
+    # so a bare `find "$MEDIAMTX_LOG_DIR" -name '*.gz' -delete` would wipe every
+    # rotated SYSTEM log (syslog, auth.log, journal exports) during an incident.
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would delete rotated LyreBird/MediaMTX logs, LyreBird temp files, and buffer contents"
+    else
+        [[ -d "$LOG_DIR" ]] && find "$LOG_DIR" -maxdepth 1 -name "*.gz" -delete 2>/dev/null || true
+        find "$MEDIAMTX_LOG_DIR" -maxdepth 1 -name "mediamtx*.out*.gz" -delete 2>/dev/null || true
 
-    # Clear temp directory
-    find "$TEMP_DIR" -maxdepth 1 -name "lyrebird-*" -type f -delete 2>/dev/null || true
+        # Clear LyreBird temp files
+        find "$TEMP_DIR" -maxdepth 1 -name "lyrebird-*" -type f -delete 2>/dev/null || true
 
-    # Clear buffer directory (with safety validation)
-    if [[ -d "$BUFFER_DIR" ]] && validate_safe_path "$BUFFER_DIR"; then
-        rm -rf "${BUFFER_DIR:?}"/* 2>/dev/null || true
+        # Clear buffer directory (with safety validation)
+        if [[ -d "$BUFFER_DIR" ]] && validate_safe_path "$BUFFER_DIR"; then
+            rm -rf "${BUFFER_DIR:?}"/* 2>/dev/null || true
+        fi
     fi
 }
 

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -3536,12 +3536,15 @@ check_devices_exist() {
 
 # Check if parent is still alive
 check_parent_alive() {
-    if [[ -n "${MAIN_SCRIPT_PID}" ]] && [[ "${MAIN_SCRIPT_PID}" -gt 1 ]]; then
-        if ! kill -0 "${MAIN_SCRIPT_PID}" 2>/dev/null; then
-            log_message "Main script (PID ${MAIN_SCRIPT_PID}) has terminated, exiting"
-            return 1
-        fi
-    fi
+    # Intentionally a no-op. MAIN_SCRIPT_PID is the transient launcher process,
+    # which exits BY DESIGN after starting the wrappers (start_mediamtx returns
+    # and the systemd unit is Type=forking). Tying wrapper lifetime to it made
+    # every wrapper exit shortly after boot, defeating auto-restart entirely.
+    # Graceful shutdown is handled by the CLEANUP_MARKER check in the loop and by
+    # `stop` terminating the wrapper process groups directly; an abnormal launcher
+    # exit creates CLEANUP_MARKER, which also stops the wrappers. Kept as a
+    # function (rather than deleting call sites) to minimise churn in the
+    # generated wrapper.
     return 0
 }
 
@@ -3597,9 +3600,13 @@ while true; do
         continue
     fi
     
-    # Wait for FFmpeg to exit
-    wait "${FFMPEG_PID}" 2>/dev/null
-    exit_code=$?
+    # Wait for FFmpeg to exit.
+    # NOTE: capture the status with `|| exit_code=$?`. A bare `wait` returns
+    # FFmpeg's (usually non-zero) exit status and, under `set -euo pipefail`,
+    # errexit would kill the wrapper HERE -- before the restart/backoff logic
+    # below -- so streams never auto-restarted after a failure.
+    exit_code=0
+    wait "${FFMPEG_PID}" 2>/dev/null || exit_code=$?
     
     FFMPEG_PID=""
     
@@ -3939,12 +3946,15 @@ check_device_exists() {
 
 # Check if parent is still alive
 check_parent_alive() {
-    if [[ -n "${MAIN_SCRIPT_PID}" ]] && [[ "${MAIN_SCRIPT_PID}" -gt 1 ]]; then
-        if ! kill -0 "${MAIN_SCRIPT_PID}" 2>/dev/null; then
-            log_message "Main script (PID ${MAIN_SCRIPT_PID}) has terminated, exiting"
-            return 1
-        fi
-    fi
+    # Intentionally a no-op. MAIN_SCRIPT_PID is the transient launcher process,
+    # which exits BY DESIGN after starting the wrappers (start_mediamtx returns
+    # and the systemd unit is Type=forking). Tying wrapper lifetime to it made
+    # every wrapper exit shortly after boot, defeating auto-restart entirely.
+    # Graceful shutdown is handled by the CLEANUP_MARKER check in the loop and by
+    # `stop` terminating the wrapper process groups directly; an abnormal launcher
+    # exit creates CLEANUP_MARKER, which also stops the wrappers. Kept as a
+    # function (rather than deleting call sites) to minimise churn in the
+    # generated wrapper.
     return 0
 }
 
@@ -3999,9 +4009,13 @@ while true; do
         continue
     fi
     
-    # Wait for FFmpeg to exit
-    wait "${FFMPEG_PID}" 2>/dev/null
-    exit_code=$?
+    # Wait for FFmpeg to exit.
+    # NOTE: capture the status with `|| exit_code=$?`. A bare `wait` returns
+    # FFmpeg's (usually non-zero) exit status and, under `set -euo pipefail`,
+    # errexit would kill the wrapper HERE -- before the restart/backoff logic
+    # below -- so streams never auto-restarted after a failure.
+    exit_code=0
+    wait "${FFMPEG_PID}" 2>/dev/null || exit_code=$?
     
     FFMPEG_PID=""
     

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -11,7 +11,12 @@
 # configurations for continuous 24/7 RTSP audio streams.
 #
 # Version: 1.4.4 - Robustness improvements
-# Compatible with MediaMTX v1.15.0+
+# Compatible with MediaMTX v1.15.0 through at least v1.19.x. The /v3 REST API
+# endpoints used here are unchanged across that range. NOTE: the path status
+# fields parsed below ("ready", "bytesReceived", "tracks") are DEPRECATED as of
+# v1.16/v1.17 in favour of "available"/"online"/"inboundBytes"/"tracks2" -- they
+# are still returned today, but a JSON-field migration (with real-hardware
+# validation) is advisable before a future MediaMTX major release removes them.
 #
 # Version History:
 # v1.4.4 - Robustness improvements
@@ -1569,7 +1574,7 @@ detect_mediamtx_api_version() {
 
 # ============================================================================
 # MediaMTX API Integration Functions (v1.4.3)
-# Complete coverage of MediaMTX v1.15.5 REST API
+# Covers the MediaMTX /v3 REST API (validated against v1.15.5 - v1.19.x)
 # ============================================================================
 
 # Make a generic API call to MediaMTX

--- a/lyrebird-updater.sh
+++ b/lyrebird-updater.sh
@@ -2083,6 +2083,14 @@ switch_version_safe() {
         # Service update marker remains for post-exec completion
         # No need to cleanup - new script will handle it
 
+        # Release our lock BEFORE exec. exec replaces the process (same PID) and
+        # does NOT fire the EXIT trap, so the lock dir would survive. The re-exec'd
+        # process would then find a lock held by its own live PID -- the staleness
+        # check cannot fire (the PID is alive and is us) -- wait LOCK_MAX_WAIT, and
+        # abort with E_LOCKED. That made every self-update fail (and orphaned the
+        # stash and the service-update marker).
+        release_lock
+
         # Replace this process with the new script
         # shellcheck disable=SC2093  # exec is intentional here for self-update
         exec "$script_path" "${restart_args[@]}"

--- a/lyrebird-updater.sh
+++ b/lyrebird-updater.sh
@@ -3055,4 +3055,7 @@ main() {
 }
 
 # Run main function
-main "$@"
+# Only execute when run directly, not when sourced (e.g. by the test suite)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test_e2e_stream_wrapper.bats
+++ b/tests/test_e2e_stream_wrapper.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# End-to-end test (no real hardware) for the FFmpeg supervisor wrapper.
+#
+# It extracts the REAL "Main restart loop" body from lyrebird-stream-manager.sh,
+# drives it with a fake `ffmpeg` that fails, and asserts the wrapper restarts it.
+# Before the C2/C3 fixes the wrapper died after the first ffmpeg exit (bare
+# `wait` under set -e) so ffmpeg would run exactly once.
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    E2E_TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$E2E_TMP" 2>/dev/null || true
+}
+
+# Extract the individual wrapper's restart loop (the 2nd "# Main restart loop"),
+# stopping before the heredoc terminator.
+_extract_restart_loop() {
+    awk '
+        /^# Main restart loop$/ { c++ }
+        c == 2 { print }
+        /^log_message "Wrapper exiting/ && c == 2 { exit }
+    ' "$PROJECT_ROOT/lyrebird-stream-manager.sh"
+}
+
+@test "wrapper restarts a failing ffmpeg without hardware [C2/C3 E2E]" {
+    # Fake ffmpeg: record each invocation, run briefly, then fail.
+    mkdir -p "$E2E_TMP/bin"
+    cat > "$E2E_TMP/bin/ffmpeg" <<EOF
+#!/bin/bash
+echo "call" >> "$E2E_TMP/calls.log"
+sleep 0.3
+exit 1
+EOF
+    chmod +x "$E2E_TMP/bin/ffmpeg"
+    : > "$E2E_TMP/calls.log"
+
+    # Assemble a runnable wrapper: test config + helpers + the REAL loop body.
+    local wrapper="$E2E_TMP/wrapper.sh"
+    {
+        echo '#!/bin/bash'
+        echo 'set -euo pipefail'
+        echo "export PATH=\"$E2E_TMP/bin:\$PATH\""
+        # Config the loop references (fast restarts, high caps so it keeps going)
+        cat <<'CFG'
+STREAM_PATH="testmic"; CARD_NUM=0; FFMPEG_PID=""
+CLEANUP_MARKER="/nonexistent/cleanup.marker"
+RESTART_COUNT=0; CONSECUTIVE_FAILURES=0
+MAX_CONSECUTIVE_FAILURES=100; MAX_WRAPPER_RESTARTS=100
+WRAPPER_SUCCESS_DURATION=300
+INITIAL_RESTART_DELAY=1; MAX_RESTART_DELAY=1; RESTART_DELAY=1
+log_message() { :; }
+log_critical() { :; }
+check_parent_alive() { return 0; }
+check_device_exists() { return 0; }
+run_ffmpeg() { ffmpeg >/dev/null 2>&1 & FFMPEG_PID=$!; return 0; }
+CFG
+        _extract_restart_loop
+    } > "$wrapper"
+
+    # The assembled wrapper must be syntactically valid.
+    bash -n "$wrapper"
+
+    # Run it for a few seconds; it loops forever until stopped.
+    timeout 5s bash "$wrapper" || true
+
+    # It must have launched ffmpeg at least twice (i.e. it RESTARTED after a
+    # failure). The pre-fix wrapper would show exactly one invocation.
+    local calls
+    calls=$(grep -c 'call' "$E2E_TMP/calls.log" 2>/dev/null || echo 0)
+    [ "$calls" -ge 2 ]
+}
+
+@test "wrapper stops when the cleanup marker appears [E2E]" {
+    mkdir -p "$E2E_TMP/bin"
+    cat > "$E2E_TMP/bin/ffmpeg" <<EOF
+#!/bin/bash
+sleep 0.2
+exit 1
+EOF
+    chmod +x "$E2E_TMP/bin/ffmpeg"
+
+    local marker="$E2E_TMP/cleanup.marker"
+    local wrapper="$E2E_TMP/wrapper.sh"
+    {
+        echo '#!/bin/bash'
+        echo 'set -euo pipefail'
+        echo "export PATH=\"$E2E_TMP/bin:\$PATH\""
+        echo "CLEANUP_MARKER=\"$marker\""
+        cat <<'CFG'
+STREAM_PATH="testmic"; CARD_NUM=0; FFMPEG_PID=""
+RESTART_COUNT=0; CONSECUTIVE_FAILURES=0
+MAX_CONSECUTIVE_FAILURES=100; MAX_WRAPPER_RESTARTS=100
+WRAPPER_SUCCESS_DURATION=300
+INITIAL_RESTART_DELAY=1; MAX_RESTART_DELAY=1; RESTART_DELAY=1
+log_message() { :; }
+log_critical() { :; }
+check_parent_alive() { return 0; }
+check_device_exists() { return 0; }
+run_ffmpeg() { ffmpeg >/dev/null 2>&1 & FFMPEG_PID=$!; return 0; }
+CFG
+        _extract_restart_loop
+    } > "$wrapper"
+
+    # Create the marker, then run: the wrapper must exit promptly (graceful stop).
+    : > "$marker"
+    run timeout 5s bash "$wrapper"
+    # timeout returns 124 only if the wrapper was still running at the deadline.
+    [ "$status" -ne 124 ]
+}

--- a/tests/test_install_mediamtx.bats
+++ b/tests/test_install_mediamtx.bats
@@ -19,6 +19,11 @@ setup() {
 
     # Source the installer script
     source "$PROJECT_ROOT/install_mediamtx.sh"
+
+    # The script enables `set -euo pipefail`, which leaks into the bats shell and
+    # turns failing assertions / unset-var reads into silent aborts. Restore
+    # bats' own error handling so failures report as "not ok".
+    set +euo pipefail
 }
 
 # Teardown - clean up temp files

--- a/tests/test_lyrebird_alerts.bats
+++ b/tests/test_lyrebird_alerts.bats
@@ -20,6 +20,11 @@ setup() {
 
     # Source the alerts script (functions only, don't run main)
     source "$PROJECT_ROOT/lyrebird-alerts.sh"
+
+    # The script enables `set -euo pipefail`, which leaks into the bats shell and
+    # turns failing assertions / unset-var reads into silent aborts. Restore
+    # bats' own error handling so failures report as "not ok".
+    set +euo pipefail
 }
 
 # Teardown - clean up temp files

--- a/tests/test_lyrebird_alerts.bats
+++ b/tests/test_lyrebird_alerts.bats
@@ -336,3 +336,38 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "LYREBIRD_ALERT_ENABLED" ]]
 }
+
+# ============================================================================
+# Regression tests for destination detection / dispatch (C5)
+# ============================================================================
+
+@test "ntfy destination is recognized without a webhook URL [C5 regression]" {
+    LYREBIRD_WEBHOOK_URL="" LYREBIRD_WEBHOOK_URLS="" \
+    LYREBIRD_WEBHOOK_TYPE="ntfy" LYREBIRD_NTFY_TOPIC="mytopic" \
+        alert_destination_configured
+}
+
+@test "pushover destination requires both token and user [C5 regression]" {
+    LYREBIRD_WEBHOOK_URL="" LYREBIRD_WEBHOOK_URLS="" LYREBIRD_WEBHOOK_TYPE="pushover"
+    run env LYREBIRD_WEBHOOK_URL="" LYREBIRD_WEBHOOK_URLS="" LYREBIRD_WEBHOOK_TYPE="pushover" \
+        LYREBIRD_PUSHOVER_TOKEN="" LYREBIRD_PUSHOVER_USER="" bash -c \
+        "source '$PROJECT_ROOT/lyrebird-alerts.sh' >/dev/null 2>&1; set +euo pipefail; alert_destination_configured"
+    [ "$status" -ne 0 ]
+    LYREBIRD_PUSHOVER_TOKEN="tok" LYREBIRD_PUSHOVER_USER="usr" \
+    LYREBIRD_WEBHOOK_URL="" LYREBIRD_WEBHOOK_URLS="" LYREBIRD_WEBHOOK_TYPE="pushover" \
+        alert_destination_configured
+}
+
+@test "send_alert actually dispatches an ntfy alert via curl [C5 regression]" {
+    # Previously send_alert returned 0 from the guard WITHOUT sending. Shim curl
+    # to record the endpoint it is called with and prove dispatch happens.
+    local calllog="${BATS_TEST_TMPDIR:-$LYREBIRD_ALERT_STATE_DIR}/curl.log"
+    : > "$calllog"
+    curl() { printf '%s\n' "$*" >> "$calllog"; printf '200'; }
+    LYREBIRD_ALERT_ENABLED="true"
+    LYREBIRD_WEBHOOK_URL="" LYREBIRD_WEBHOOK_URLS=""
+    LYREBIRD_WEBHOOK_TYPE="ntfy" LYREBIRD_NTFY_TOPIC="t" LYREBIRD_NTFY_SERVER="https://ntfy.example"
+    run send_alert "info" "Stream Down: mic1" "Body text" "test"
+    [ "$status" -eq 0 ]
+    grep -q 'ntfy.example/t' "$calllog"
+}

--- a/tests/test_lyrebird_alerts.bats
+++ b/tests/test_lyrebird_alerts.bats
@@ -371,3 +371,25 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -q 'ntfy.example/t' "$calllog"
 }
+
+# ============================================================================
+# Regression tests for JSON escaping validity (H10)
+# ============================================================================
+
+@test "json_escape yields a valid JSON string for control chars/backslash [H10 regression]" {
+    # backslash, quote, newline, tab, ESC (0x1b), backspace (0x08), formfeed (0x0c)
+    local msg; msg=$(printf 'a\\b"c\nd\te\033f\010g\014h')
+    local esc; esc=$(json_escape "$msg")
+    # Wrapping the escaped output in quotes must parse as a JSON string.
+    run python3 -c 'import json,sys; json.loads("\""+sys.argv[1]+"\""); print("OK")' "$esc"
+    [ "$status" -eq 0 ]
+    [ "$output" = "OK" ]
+}
+
+@test "format_discord payload is valid JSON with a hostile message [H10 regression]" {
+    # ANSI colour codes (ESC), newline, tab, quotes, backslash, and a colon title.
+    local msg; msg=$(printf 'ffmpeg \033[31merror\033[0m\nline2\ttab "q" \\ back')
+    run format_discord "critical" "Stream Down: mic1" "$msg" "stream_down"
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c 'import json,sys; json.load(sys.stdin); print("valid")'
+}

--- a/tests/test_lyrebird_diagnostics.bats
+++ b/tests/test_lyrebird_diagnostics.bats
@@ -538,3 +538,27 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" =~ ^[0-9]+$ ]]
 }
+
+# ============================================================================
+# Regression tests for the grep -c "double-zero" arithmetic abort (H4)
+# ============================================================================
+
+@test "log-count arithmetic does not abort a healthy diagnostic under set -e [H4 regression]" {
+    local qlog="${BATS_TEST_TMPDIR:-/tmp}/quiet.$$.log"
+    printf 'all fine\nnothing to see here\n' > "$qlog"
+    # OLD buggy form: grep -ic prints "0" AND '|| echo 0' prints another -> "0\n0"
+    # -> $(( "0\n0" )) is an arithmetic syntax error -> set -e aborts the run.
+    run env Q="$qlog" bash -c 'set -euo pipefail; n=$(($(grep -ic "error" "$Q" || echo 0))); echo "n=$n"'
+    [ "$status" -ne 0 ]
+    # NEW form used by the code: '|| true' keeps grep's own single "0" and stops
+    # the non-zero exit from aborting the (set -e) assignment.
+    run env Q="$qlog" bash -c 'set -euo pipefail; n=$(($(grep -ic "error" "$Q" || true) + 0)); echo "n=$n"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "n=0" ]
+    rm -f "$qlog"
+}
+
+@test "diagnostics no longer uses grep -c ... || echo 0 [H4 regression]" {
+    run grep -nE 'grep -[a-z]*c[a-z]* [^|]*\|\| echo 0' "$PROJECT_ROOT/lyrebird-diagnostics.sh"
+    [ "$status" -ne 0 ]
+}

--- a/tests/test_lyrebird_diagnostics.bats
+++ b/tests/test_lyrebird_diagnostics.bats
@@ -380,7 +380,12 @@ EOF
 
 @test "get_primary_interface returns interface name" {
     get_primary_interface() {
-        ip route 2>/dev/null | awk '/default/{print $5; exit}' || echo "unknown"
+        # NOTE: `awk` succeeds (exit 0) even with no match, so `|| echo` never
+        # fires; default with parameter expansion instead. A host with no
+        # default route (e.g. a CI container) legitimately has no primary iface.
+        local iface
+        iface=$(ip route 2>/dev/null | awk '/default/{print $5; exit}')
+        echo "${iface:-unknown}"
     }
 
     run get_primary_interface

--- a/tests/test_lyrebird_metrics.bats
+++ b/tests/test_lyrebird_metrics.bats
@@ -235,3 +235,31 @@ teardown() {
     run bash -c "source $PROJECT_ROOT/lyrebird-metrics.sh && collect_mediamtx_metrics && collect_system_metrics"
     [ "$status" -eq 0 ]
 }
+
+# ============================================================================
+# Regression tests for Prometheus exposition-format validity (C6, M2)
+# ============================================================================
+
+@test "no metric family emits duplicate HELP/TYPE with multiple streams [C6 regression]" {
+    # >=2 streams and 3 disk mounts previously produced repeated HELP/TYPE lines,
+    # which makes the Prometheus text parser reject the ENTIRE scrape.
+    # FFMPEG_PID_DIR is created (and made readonly) by setup(); populate it.
+    echo $$ > "$FFMPEG_PID_DIR/mic1.pid"
+    echo $$ > "$FFMPEG_PID_DIR/mic2.pid"
+    output="$( { collect_system_metrics; collect_stream_metrics; } 2>/dev/null )"
+
+    # Each metric name may appear in at most one '# HELP' and one '# TYPE' line.
+    dup_help="$(printf '%s\n' "$output" | awk '/^# HELP /{c[$3]++} END{for(n in c) if(c[n]>1) print n}')"
+    [ -z "$dup_help" ]
+    dup_type="$(printf '%s\n' "$output" | awk '/^# TYPE /{c[$3]++} END{for(n in c) if(c[n]>1) print n}')"
+    [ -z "$dup_type" ]
+}
+
+@test "no sample line is emitted with an empty value [C6/M2 regression]" {
+    echo $$ > "$FFMPEG_PID_DIR/mic1.pid"
+    output="$( { collect_system_metrics; collect_stream_metrics; } 2>/dev/null )"
+    # A metric/sample line must end with a value; reject a name (optionally with
+    # labels) followed by only whitespace/EOL.
+    run bash -c 'printf "%s\n" "$1" | grep -nE "^[a-zA-Z_][a-zA-Z0-9_:]*(\{[^}]*\})?[[:space:]]*$"' _ "$output"
+    [ "$status" -ne 0 ]
+}

--- a/tests/test_lyrebird_metrics.bats
+++ b/tests/test_lyrebird_metrics.bats
@@ -16,6 +16,11 @@ setup() {
 
     # Source the metrics script
     source "$PROJECT_ROOT/lyrebird-metrics.sh"
+
+    # The script enables `set -euo pipefail`, which leaks into the bats shell and
+    # turns failing assertions / unset-var reads into silent aborts. Restore
+    # bats' own error handling so failures report as "not ok".
+    set +euo pipefail
 }
 
 # Teardown - clean up temp files

--- a/tests/test_lyrebird_mic_check.bats
+++ b/tests/test_lyrebird_mic_check.bats
@@ -16,6 +16,11 @@ setup() {
 
     # Source the mic check script
     source "$PROJECT_ROOT/lyrebird-mic-check.sh"
+
+    # The script enables `set -euo pipefail`, which leaks into the bats shell and
+    # turns failing assertions / unset-var reads into silent aborts. Restore
+    # bats' own error handling so failures report as "not ok".
+    set +euo pipefail
 }
 
 # Teardown - clean up temp files

--- a/tests/test_lyrebird_mic_check.bats
+++ b/tests/test_lyrebird_mic_check.bats
@@ -300,3 +300,30 @@ teardown() {
 @test "PROC_ASOUND_CARDS path is defined" {
     [ -n "$PROC_ASOUND_CARDS" ]
 }
+
+# ============================================================================
+# Regression tests for the device-config key contract (C4)
+# ============================================================================
+
+@test "generate_config emits UPPERCASE device keys [C4 regression]" {
+    # The stream manager reads DEVICE_${name^^}_${param^^}; the generator must
+    # emit the same uppercase names or every per-device setting is ignored.
+    grep -qE 'DEVICE_\$\{safe_name\^\^\}_SAMPLE_RATE=' "$PROJECT_ROOT/lyrebird-mic-check.sh"
+    run grep -cE 'DEVICE_\$\{safe_name\}_(SAMPLE_RATE|CHANNELS|BITRATE)=' "$PROJECT_ROOT/lyrebird-mic-check.sh"
+    [ "$output" -eq 0 ]
+}
+
+@test "device key for a normal device matches stream-manager's lookup [C4 contract]" {
+    # sanitize_device_name is sourced from mic-check in setup(). The uppercased
+    # key must equal what stream-manager's get_device_config looks up.
+    local name; name="$(sanitize_device_name "Blue Yeti")"
+    [ "DEVICE_${name^^}_SAMPLE_RATE" = "DEVICE_BLUE_YETI_SAMPLE_RATE" ]
+}
+
+@test "get_config_value reads UPPERCASE keys so --validate stays consistent [C4 regression]" {
+    # A config written by generate_config must be readable by mic-check itself.
+    DEVICE_BLUE_YETI_SAMPLE_RATE=96000
+    run get_config_value "Blue_Yeti" "" "SAMPLE_RATE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "96000" ]
+}

--- a/tests/test_lyrebird_orchestrator.bats
+++ b/tests/test_lyrebird_orchestrator.bats
@@ -668,3 +668,17 @@ teardown() {
     run validate_pid "abc"
     [ "$status" -eq 1 ]
 }
+
+# ============================================================================
+# Regression test for interactive-delegation stdin (C8)
+# ============================================================================
+
+@test "delegations receive the controlling terminal, not /dev/null [C8 regression]" {
+    # A backgrounded command's stdin defaults to /dev/null, so interactive
+    # delegations (USB mapper, updater menu, uninstall confirm) read EOF and
+    # abort. Every exec site must give the child </dev/tty.
+    run grep -c -F '"${args[@]}" &' "$PROJECT_ROOT/lyrebird-orchestrator.sh"
+    [ "$output" -eq 0 ]
+    run grep -c -F '"${args[@]}" </dev/tty &' "$PROJECT_ROOT/lyrebird-orchestrator.sh"
+    [ "$output" -eq 3 ]
+}

--- a/tests/test_lyrebird_storage.bats
+++ b/tests/test_lyrebird_storage.bats
@@ -375,3 +375,50 @@ teardown() {
     run type main
     [ "$status" -eq 0 ]
 }
+
+# ============================================================================
+# Regression tests (exercise the REAL functions with proper path overrides)
+# ============================================================================
+
+@test "cleanup_recordings survives a 0-byte recording under set -e [H1 regression]" {
+    local rec; rec="$(mktemp -d)"
+    : > "$rec/old.wav"                                   # 0-byte recording
+    touch -d "400 days ago" "$rec/old.wav" 2>/dev/null || touch "$rec/old.wav"
+    # ((freed_bytes += size)) returned exit 1 when the running total was still 0
+    # and the file was 0 bytes; under set -e that aborted cleanup mid-run, so the
+    # disk kept filling. Must now complete cleanly.
+    run env PROJECT_ROOT="$PROJECT_ROOT" LYREBIRD_RECORDING_DIR="$rec" DRY_RUN=false \
+        bash -c 'set -euo pipefail; source "$PROJECT_ROOT/lyrebird-storage.sh"; cleanup_recordings'
+    rm -rf "$rec"
+    [ "$status" -eq 0 ]
+}
+
+@test "emergency_cleanup does not delete unrelated system logs [H2 regression]" {
+    local logdir; logdir="$(mktemp -d)"
+    : > "$logdir/syslog.1.gz"           # unrelated system log
+    : > "$logdir/mediamtx.out.1.gz"     # our own rotated log
+    run env PROJECT_ROOT="$PROJECT_ROOT" MEDIAMTX_LOG="$logdir/mediamtx.out" \
+        LYREBIRD_RECORDING_DIR="$(mktemp -d)" LYREBIRD_LOG_DIR="$(mktemp -d)" \
+        LYREBIRD_BUFFER_DIR="$(mktemp -d)" DRY_RUN=false \
+        bash -c 'source "$PROJECT_ROOT/lyrebird-storage.sh"; emergency_cleanup'
+    local survived=0
+    [ -f "$logdir/syslog.1.gz" ] && survived=1
+    rm -rf "$logdir"
+    [ "$survived" -eq 1 ]              # MEDIAMTX_LOG_DIR is /var/log in production
+}
+
+@test "emergency_cleanup with DRY_RUN deletes nothing [H3 regression]" {
+    local logdir; logdir="$(mktemp -d)"; local buf; buf="$(mktemp -d)"
+    : > "$logdir/mediamtx.out.1.gz"
+    : > "$buf/chunk.raw"
+    run env PROJECT_ROOT="$PROJECT_ROOT" MEDIAMTX_LOG="$logdir/mediamtx.out" \
+        LYREBIRD_RECORDING_DIR="$(mktemp -d)" LYREBIRD_LOG_DIR="$(mktemp -d)" \
+        LYREBIRD_BUFFER_DIR="$buf" DRY_RUN=true \
+        bash -c 'source "$PROJECT_ROOT/lyrebird-storage.sh"; emergency_cleanup'
+    local gz=0 raw=0
+    [ -f "$logdir/mediamtx.out.1.gz" ] && gz=1
+    [ -f "$buf/chunk.raw" ] && raw=1
+    rm -rf "$logdir" "$buf"
+    [ "$gz" -eq 1 ]
+    [ "$raw" -eq 1 ]
+}

--- a/tests/test_lyrebird_storage.bats
+++ b/tests/test_lyrebird_storage.bats
@@ -23,6 +23,12 @@ setup() {
 
     # Source the storage script
     source "$PROJECT_ROOT/lyrebird-storage.sh"
+
+    # The script enables `set -euo pipefail`, which leaks into the bats test
+    # shell and turns failing assertions / unset-var reads into silent aborts
+    # (bats loses control of errexit and stops emitting results). Restore bats'
+    # own error handling so failures report as "not ok" instead of vanishing.
+    set +euo pipefail
 }
 
 # Teardown - clean up temp directories

--- a/tests/test_lyrebird_updater.bats
+++ b/tests/test_lyrebird_updater.bats
@@ -20,6 +20,10 @@ setup() {
 
     # Source the updater script
     source "$PROJECT_ROOT/lyrebird-updater.sh"
+
+    # The script enables errexit, which leaks into the bats shell and turns
+    # failing assertions into silent aborts. Restore bats' own error handling.
+    set +euo pipefail
 }
 
 # Teardown - clean up temp files

--- a/tests/test_lyrebird_updater.bats
+++ b/tests/test_lyrebird_updater.bats
@@ -356,3 +356,25 @@ teardown() {
     run type cleanup
     [ "$status" -eq 0 ]
 }
+
+# ============================================================================
+# Regression tests for self-update lock handling (C7)
+# ============================================================================
+
+@test "self-update releases the lock immediately before exec [C7 regression]" {
+    # exec keeps the same PID and does NOT fire the EXIT trap, so the lock must be
+    # released explicitly before exec or the re-exec'd process deadlocks on its
+    # own live-PID lock and every self-update fails with E_LOCKED.
+    run grep -B6 -F 'exec "$script_path" "${restart_args[@]}"' "$PROJECT_ROOT/lyrebird-updater.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"release_lock"* ]]
+}
+
+@test "release_lock removes a lock owned by the current PID [C7 regression]" {
+    mkdir -p "$LOCKFILE"
+    echo "$$" > "$LOCKFILE/pid"
+    [ -d "$LOCKFILE" ]
+    release_lock
+    [ ! -d "$LOCKFILE" ]
+    rm -rf "$LOCKFILE" 2>/dev/null || true
+}

--- a/tests/test_stream_manager.bats
+++ b/tests/test_stream_manager.bats
@@ -523,3 +523,53 @@ setup() {
     run process_exists 999999999
     [ "$status" -eq 1 ]
 }
+
+# ============================================================================
+# Regression tests for the FFmpeg wrapper self-healing loop (C2/C3)
+# The wrapper is generated text run under `set -euo pipefail`, so these guard
+# the generated source AND prove the underlying bash mechanism.
+# ============================================================================
+
+@test "wrapper wait preserves exit code without tripping errexit [C2 regression]" {
+    # Both wrappers (individual + multiplex) must use the safe idiom.
+    run grep -c 'wait "${FFMPEG_PID}" 2>/dev/null || exit_code=$?' \
+        "$PROJECT_ROOT/lyrebird-stream-manager.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 2 ]
+    # The old bare-wait-then-$? pattern must be gone (would let errexit kill the
+    # wrapper on FFmpeg's first non-zero exit, before restart/backoff ran).
+    run grep -nE '^[[:space:]]*wait "\$\{FFMPEG_PID\}" 2>/dev/null[[:space:]]*$' \
+        "$PROJECT_ROOT/lyrebird-stream-manager.sh"
+    [ "$status" -ne 0 ]
+}
+
+@test "safe wait idiom survives a non-zero child under set -e [C2 mechanism]" {
+    run bash -c '
+        set -euo pipefail
+        ( exit 3 ) & p=$!          # stand-in for FFmpeg dying non-zero
+        exit_code=0
+        wait "$p" 2>/dev/null || exit_code=$?
+        echo "reached restart logic ec=$exit_code"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reached restart logic ec=3"* ]]
+}
+
+@test "old bare-wait idiom aborts under set -e [C2 characterization]" {
+    # Documents the bug this fixes: control never reaches the restart logic.
+    run bash -c '
+        set -euo pipefail
+        ( exit 3 ) & p=$!
+        wait "$p" 2>/dev/null
+        echo "reached restart logic"
+    '
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"reached restart logic"* ]]
+}
+
+@test "wrapper does not tie its lifetime to the transient launcher PID [C3 regression]" {
+    # check_parent_alive must be neutralised: MAIN_SCRIPT_PID is the launcher,
+    # which exits by design, so killing the wrapper on its death defeats restart.
+    run grep -c 'kill -0 "${MAIN_SCRIPT_PID}"' "$PROJECT_ROOT/lyrebird-stream-manager.sh"
+    [ "$output" -eq 0 ]
+}

--- a/tests/test_usb_audio_mapper.bats
+++ b/tests/test_usb_audio_mapper.bats
@@ -185,20 +185,40 @@ teardown() {
 # udev Rule Generation Tests
 # ============================================================================
 
-@test "generate_udev_rule creates valid symlink" {
-    generate_udev_rule() {
-        local vid="$1"
-        local pid="$2"
-        local name="$3"
-        echo "ACTION==\"add\", SUBSYSTEM==\"sound\", ATTRS{idVendor}==\"$vid\", ATTRS{idProduct}==\"$pid\", ATTR{id}=\"$name\""
-    }
-
-    run generate_udev_rule "1234" "5678" "test_mic"
+@test "generate_udev_rules emits an active (non-comment) udev rule [C1 regression]" {
+    # Exercises the REAL function, not a local mock. The historical bug stored a
+    # literal "\n" in a double-quoted string and printed it with printf '%s', so
+    # the comment and the rule collapsed onto one '#'-prefixed line and udev
+    # ignored the entire rule -- USB persistent naming silently never worked.
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+        set +euo pipefail
+        source "$PROJECT_ROOT/usb-audio-mapper.sh" >/dev/null 2>&1
+        generate_udev_rules "0d8c" "0014" "test-mic" "Blue Yeti" "1-1.4" ""
+    '
     [ "$status" -eq 0 ]
-    [[ "$output" =~ ACTION==\"add\" ]]
-    [[ "$output" =~ idVendor==\"1234\" ]]
-    [[ "$output" =~ idProduct==\"5678\" ]]
-    [[ "$output" =~ id=\"test_mic\" ]]
+    # At least one ACTIVE (non-#) line must exist; the bug produced zero.
+    [ "$(printf '%s\n' "$output" | grep -vc '^[[:space:]]*#')" -ge 1 ]
+    # It is a real udev rule that applies the persistent id.
+    printf '%s\n' "$output" | grep -qE '^SUBSYSTEM=="sound".*ATTR\{id\}="test-mic"'
+    # No stray literal backslash-n survived into the output.
+    [[ "$output" != *'\n'* ]]
+}
+
+@test "generate_udev_rules strips injection from the card name [H7 regression]" {
+    # A card name carrying a newline + RUN+= must not yield an active udev
+    # directive other than the intended SUBSYSTEM rule. The old tr set
+    # '[:alnum:] \t-_.' was read as the range 0x09-0x5F and let newlines through.
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+        set +euo pipefail
+        source "$PROJECT_ROOT/usb-audio-mapper.sh" >/dev/null 2>&1
+        evil=$(printf "pwned\nRUN+=\"/bin/sh -c evilcmd\"")
+        generate_udev_rules "0d8c" "0014" "good-mic" "$evil" "1-1.4" ""
+    '
+    [ "$status" -eq 0 ]
+    # No RUN/PROGRAM/IMPORT directive anywhere in the output.
+    ! printf '%s\n' "$output" | grep -qE "RUN[+]=|PROGRAM==|IMPORT[{]"
+    # Exactly one active (non-comment) line: the intended rule.
+    [ "$(printf '%s\n' "$output" | grep -vc '^[[:space:]]*#')" -eq 1 ]
 }
 
 # ============================================================================

--- a/usb-audio-mapper.sh
+++ b/usb-audio-mapper.sh
@@ -617,12 +617,16 @@ generate_udev_rules() {
         error_exit "Missing required parameters for rule generation"
     fi
 
-    # Sanitize card name
+    # Sanitize card name (used only in the human-readable comment).
+    # NOTE: the hyphen must be LAST in the tr set so it is a literal, not a
+    # range. The previous set '[:alnum:] \t-_.' was read as the range 0x09-0x5F,
+    # which let quotes, '$', ';', '=', and (crucially) newlines through — a udev
+    # rule-injection vector. This set keeps only alnum, space, '.', '_', '-'.
     local safe_card_name
-    safe_card_name=$(printf '%s' "$card_name" | tr -cd '[:alnum:] \t-_.' | tr -s ' ')
+    safe_card_name=$(printf '%s' "$card_name" | tr -cd '[:alnum:] ._-' | tr -s ' ')
 
-    # Build rule comment
-    local rules="# USB Sound Card: ${safe_card_name:-$friendly_name}\n"
+    # Build rule comment (emitted on its own physical line — see printf below)
+    local rule_comment="# USB Sound Card: ${safe_card_name:-$friendly_name}"
 
     # Build rule content
     local rules_content="SUBSYSTEM==\"sound\", ATTRS{idVendor}==\"$vendor_id\", ATTRS{idProduct}==\"$product_id\""
@@ -641,8 +645,13 @@ generate_udev_rules() {
     # Complete the rule
     rules_content+=", ATTR{id}=\"$friendly_name\", SYMLINK+=\"sound/by-id/$friendly_name\""
 
-    rules+="$rules_content"
-    printf '%s' "$rules"
+    # Emit the comment and the rule on SEPARATE physical lines.
+    # A previous version stored a literal "\n" inside a double-quoted string
+    # (bash does not expand "\n" in double quotes) and printed it with
+    # printf '%s', collapsing the comment and the rule onto a single
+    # '#'-prefixed line. udev then treated the ENTIRE rule as a comment, so
+    # ATTR{id} was never applied and devices were never persistently renamed.
+    printf '%s\n%s\n' "$rule_comment" "$rules_content"
 }
 
 # Function to write rules atomically with deduplication

--- a/usb-audio-mapper.sh
+++ b/usb-audio-mapper.sh
@@ -1229,4 +1229,7 @@ main() {
 }
 
 # Entry point
-main "$@"
+# Only execute when run directly, not when sourced (e.g. by the test suite)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary

A full line-by-line correctness/reliability audit of every script (~22k lines of Bash) and every test (~4.5k lines), driven by static analysis (`bash -n`, ShellCheck, shfmt, checkbashisms) plus deep manual review, with a current MediaMTX (v1.19.2) compatibility pass.

The headline: several **core features silently did not work**, and the test suite hid it. Every fix below is verified against the actual code (many by executing it) and ships with a fail-before/pass-after regression test.

Full severity-ranked register: `docs/ENGINEERING-REVIEW-2026-07.md`.

## The test suite was giving false confidence

- **3 test files ran 0 of their tests** (install/storage/updater) — a bare `main "$@"` at end-of-file meant sourcing them under bats ran `main` and called `exit`, silently aborting **159 tests**.
- Sourced `set -euo pipefail` leaked into the bats shell, turning failing assertions into invisible aborts.
- **CI never ran bats at all** — so every bug below passed CI green.

Fixed the harness (entry-point source guards + restoring bats' error handling) so all tests execute, and added a **required `bats-tests` CI gate**. Many existing tests also asserted against local mock reimplementations rather than the real functions; the regressions added here exercise the real code.

## CRITICAL defects fixed (each with a regression test)

| Component | Defect |
|---|---|
| **usb-audio-mapper** | Every generated udev rule was emitted as a **comment** — a literal `\n` collapsed the comment and rule onto one `#`-prefixed line, so udev ignored it and **USB persistent naming never worked** (verified: 0 active rules). Also fixed an injection-prone card-name sanitizer (`tr` range let newlines through → root `RUN+=`). |
| **stream-manager** | FFmpeg streams **did not auto-restart**: the supervisor wrapper died on the first FFmpeg failure (bare `wait` under `set -e`) and again when the transient launcher PID exited (`MAIN_SCRIPT_PID`). Restored the backoff-restart loop; validated end-to-end with a fake ffmpeg. |
| **mic-check ↔ stream-manager** | Device config written `DEVICE_<name>_*` in a case the stream manager's `${name^^}` lookup never matched → **every per-device setting ignored**; a "192 kHz high" mic silently ran at 48000/2/128k and `--validate` falsely passed. |
| **lyrebird-alerts** | ntfy/Pushover configs **silently dropped every alert** and reported "sent successfully". |
| **lyrebird-metrics** | Duplicate `# HELP`/`# TYPE` lines → **Prometheus rejects the entire scrape**. |
| **lyrebird-updater** | **Self-update always failed** — deadlocked on its own lock after `exec` (same PID, EXIT trap skipped). |
| **lyrebird-orchestrator** | Backgrounded interactive delegations got `stdin=/dev/null` → the **Quick Setup Wizard could not map devices**. |

## HIGH defects fixed

- **storage**: cleanup **aborted on a 0-byte file** (`((freed_bytes += size))` returns 1 under `set -e`) → disk-fill risk; emergency cleanup wiped unrelated `/var/log/*.gz` and ignored `--dry-run`.
- **diagnostics**: `grep -c … || echo 0` produced `0\n0` → arithmetic abort of a **healthy-host `debug` run** under `set -e`.
- **alerts / mic-check**: JSON output is now valid for control characters (ESC/`\b`/`\f`) and backslashes (previously dropped Discord/Slack webhooks).

### Cross-cutting root cause

`set -euo pipefail` colliding with Bash idioms (`wait`, `((x+=y))`, `grep -c || echo 0`, unset vars) causes **silent aborts** — found independently in stream-manager, storage, diagnostics, and the tests.

## MediaMTX (current latest: v1.19.2)

The `/v3` REST endpoints and the download/checksum asset scheme are **unchanged** from v1.15.x, and the suite emits **no** removed config keys (`fallback`, `authJWTInHTTPQuery`) — the real "won't start after upgrade" risk. Documented support through v1.19.x and flagged the now-deprecated status fields (`ready`, `bytesReceived`, `tracks`) for a future, hardware-validated migration (left unchanged to avoid regressing the count-based health checks).

## Hardware-free E2E

Added a test that drives the **real** wrapper restart loop against a PATH-shim ffmpeg — no USB mic, ALSA device, or MediaMTX required.

## Verification

- `bash -n`: all scripts pass
- ShellCheck (`--severity=warning --external-sources`, the CI gate): **0** issues
- **473 tests passing**, now enforced by CI

## Deliberately left for real-hardware validation

The stream-manager **supervision architecture** (the `start` process exits, cron `monitor` is report-only, and the shipped service is `Type=simple` while the script generates `Type=forking`) and the deprecated-MediaMTX-JSON-field migration both need validation on real hardware before changing. These and the remaining MEDIUM/LOW items are catalogued in the audit doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192QXT6xtZVWvs9xYzWQ6dR

---
_Generated by [Claude Code](https://claude.ai/code/session_0192QXT6xtZVWvs9xYzWQ6dR)_