### PR TITLE
Reliability audit (3rd pass): close deferred trio, kill silent-abort class, harden long-horizon/cold-start paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Reliability Audit (2026-07, third pass)
+
+A third adversarial, hardware-free reliability pass focused on the long-horizon
+and cold-start failure modes an unattended field node hits over weeks/months.
+Every fix ships with a regression test that fails before and passes after; the
+suite grew from 528 to 579 tests, all green, ShellCheck-clean. See
+`docs/ENGINEERING-REVIEW-2026-07.md` §8 for the reproduced findings.
+
+Component versions bumped: `lyrebird-stream-manager.sh` 1.4.3 → 1.5.0,
+`lyrebird-metrics.sh` 1.1.0 → 1.2.0, `lyrebird-storage.sh` 1.0.0 → 1.1.0.
+
+#### Deferred trio — closed with simulation proof
+- **Deep health check (H9)**: `monitor_streams` now probes the MediaMTX control
+  API for each path's readiness, not just the wrapper's bash PID. A stream whose
+  path stays not-ready for `DEEP_HEALTH_MAX_STRIKES` (default 3) consecutive
+  monitor runs — a hung FFmpeg or endless backoff — is restarted within the
+  existing cron budget. An unreachable API neither strikes nor forgives a
+  stream; a ready probe resets the streak; `DEEP_HEALTH_CHECK_ENABLED=false`
+  restores the old shallow behavior.
+- **Deprecated MediaMTX JSON fields**: readiness parsing now accepts both the
+  deprecated (`ready`) and current (`available`) path-status shapes, preferring
+  the new field, across all five grep sites (stream-manager ×4, metrics ×1). A
+  future MediaMTX that drops `ready` no longer makes every stream look dead.
+- **Non-monotonic timing**: wrapper run-time/backoff, the cron restart budget,
+  and silence tracking now read `/proc/uptime` (monotonic) instead of wall-clock
+  `date +%s`. An NTP step on an RTC-less Pi no longer counts a healthy multi-hour
+  run as a failure, evaporates the anti-storm budget, or fires a false DEAD MIC.
+
+#### Fixed
+- **errexit/pipefail silent aborts**: swept 15 more `var=$(… | grep …)` sites
+  across seven scripts where a zero-match grep aborted the whole run under
+  `set -euo pipefail` (NTP probe on an unsynced daemon, audio-level check with no
+  volumedetect output, metrics scrape when MediaMTX exits mid-scrape, checksum
+  verification, service-env merge, and more). Idle-server counting in the stream
+  manager (`0 ready paths`/`0 sessions`) was aborting too.
+- **Corrupt device config aborted `start`**: a config truncated by power loss,
+  SD-card bit-rot, or a bad operator edit hit a syntax error that aborted the
+  whole run under errexit — no streams came up on the next unattended boot. The
+  config is now syntax-checked before sourcing and ignored if corrupt; a valid
+  config is sourced with errexit neutralised and still fully honored.
+- **Non-numeric env knobs aborted the cron monitor**: 37 numeric knobs in the
+  stream manager (e.g. `CRON_RESTART_MAX_PER_HOUR=unlimited`) reached bash
+  arithmetic and killed every cron pass with an "unbound variable" error. All
+  are now coerced to sane defaults at load; valid overrides are preserved.
+- **Broken-clock mass deletion**: age-based recording retention is skipped while
+  the system clock is pre-2025 (not yet NTP-synced), and any recording whose
+  mtime predates that epoch is kept — preventing minutes-old data from being
+  deleted as "56 years old" the moment the clock steps. Emergency size-based
+  cleanup is deliberately exempt.
+
+#### Added
+- **Inode-exhaustion detection** in storage monitoring: a recorder writing many
+  small files exhausts inodes long before blocks; `cmd_monitor` now applies the
+  warning/critical/emergency thresholds to `df -Pi` too. Filesystems without
+  inode accounting are treated as no pressure.
+- **In-band metrics staleness marker**: every scrape emits
+  `lyrebird_scrape_timestamp_seconds` so a `.prom` left behind by a dead exporter
+  ("dead recorder looks alive") is detectable via a Prometheus age alert.
 
 ## [1.3.0] - 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -474,6 +474,14 @@ sudo ./lyrebird-diagnostics.sh full
 sudo ./lyrebird-stream-manager.sh install  # Creates cron job
 ```
 
+The cron monitor performs a **deep** health check: besides verifying each
+stream's supervisor process exists, it asks the MediaMTX API whether the
+stream is actually publishing audio. A stream that stays silent-side-up for
+three consecutive checks (a hung FFmpeg, a stuck retry loop) is automatically
+restarted, within a per-hour budget that prevents restart storms. No
+configuration is needed — it is on by default and does nothing when the API
+is briefly unreachable, so it never adds churn.
+
 ---
 
 ## Configuration Guide
@@ -588,6 +596,15 @@ MAX_CONSECUTIVE_FAILURES=5
 INITIAL_RESTART_DELAY=10
 MAX_RESTART_DELAY=300
 
+# Health monitoring (cron monitor)
+DEEP_HEALTH_CHECK_ENABLED=true   # Also verify each stream is actually
+                                 # publishing via the MediaMTX API, not just
+                                 # that its supervisor process exists
+DEEP_HEALTH_MAX_STRIKES=3        # Consecutive "not publishing" checks before
+                                 # a stuck stream is restarted
+CRON_RESTART_MAX_PER_HOUR=6      # Per-stream restart budget under cron
+                                 # (prevents restart storms)
+
 # Audio defaults (when not in config file)
 DEFAULT_SAMPLE_RATE=48000
 DEFAULT_CHANNELS=2
@@ -628,6 +645,14 @@ FFMPEG_LOG_DIR=/mnt/storage/logs ./lyrebird-stream-manager.sh start
 # Increase startup delay for slow USB devices
 STREAM_STARTUP_DELAY=20 ./lyrebird-stream-manager.sh start
 ```
+
+**Typo-safe:** every numeric setting above is validated when the scripts
+start. A value that isn't a plain number (e.g. `MAX_RESTART_DELAY=5min` or
+`CRON_RESTART_MAX_PER_HOUR=unlimited`) is ignored and the built-in default is
+used instead — a mistyped setting can never stop monitoring or streaming. The
+same applies to the device config file: if it is ever corrupted (power loss
+mid-write, SD-card wear), streams still start with safe defaults rather than
+failing to come up.
 
 ### Multiplex Streaming
 
@@ -1446,13 +1471,13 @@ This modular design prevents duplicate business logic and ensures maintainabilit
 |--------|---------|---------|
 | lyrebird-orchestrator.sh | 2.1.2 | Unified management interface |
 | lyrebird-updater.sh | 1.5.1 | Version management with rollback |
-| lyrebird-stream-manager.sh | 1.4.3 | Stream lifecycle management |
+| lyrebird-stream-manager.sh | 1.5.0 | Stream lifecycle management |
 | usb-audio-mapper.sh | 1.2.1 | USB device persistence via udev |
 | lyrebird-mic-check.sh | 1.0.0 | Hardware capability detection |
 | lyrebird-diagnostics.sh | 1.0.2 | System diagnostics |
 | install_mediamtx.sh | 2.0.1 | MediaMTX installation/upgrade |
-| lyrebird-metrics.sh | 1.0.0 | Prometheus metrics export |
-| lyrebird-storage.sh | 1.0.0 | Storage management & cleanup |
+| lyrebird-metrics.sh | 1.2.0 | Prometheus metrics export |
+| lyrebird-storage.sh | 1.1.0 | Storage management & cleanup |
 | lyrebird-alerts.sh | 1.0.0 | Webhook alerting system |
 
 ### Configuration Files
@@ -2028,10 +2053,15 @@ LOG_DIR="/var/log/lyrebird"
 **Features:**
 - Configurable retention policies
 - Automatic cleanup of old recordings and logs
-- Disk usage monitoring with thresholds
+- Disk usage monitoring with thresholds — including **inode** exhaustion,
+  which many small recording files can hit long before disk space runs out
 - Emergency cleanup mode for critical situations
 - Integration with alerting system
 - Dry-run mode for testing
+- **Broken-clock protection**: a Pi without a battery-backed clock boots
+  thinking it is 1970 until it gets network time. Recordings captured in that
+  window are never deleted as "too old" once the clock corrects itself, and
+  age-based cleanup waits until the clock is sane
 
 **Automated Cleanup via Cron:**
 ```bash

--- a/docs/ENGINEERING-REVIEW-2026-07.md
+++ b/docs/ENGINEERING-REVIEW-2026-07.md
@@ -301,3 +301,43 @@ backup prune no-ops on BSD; INT/TERM handler `return`s and gates rollback on `$?
 
 Every fix is verified against the actual code; line numbers are from the state
 at review time and may shift as fixes land.
+
+---
+
+## 8. Third audit pass — long-horizon & cold-start (2026-07)
+
+A third adversarial, **hardware-free** pass. Focus: the failure modes an
+unattended field node hits over weeks/months (clock steps, corrupt config,
+resource exhaustion) and the three items the second pass deferred. Every finding
+below was **reproduced with a runnable artifact** (a PATH-shim, a stub API, or a
+bats test that fails before the fix) — no speculative entries. Suite: **528 →
+579 tests**, green, ShellCheck-clean at `--severity=warning`.
+
+**Deferred trio — closed with simulation proof:**
+
+| # | Sev | Component | Failure (state → wrong outcome) | Repro | Fix | Test |
+|---|-----|-----------|---------------------------------|-------|-----|------|
+| D1 | HIGH | stream-manager `monitor_streams` | Health check verified only the wrapper bash PID → a hung FFmpeg / endless-backoff stream whose MediaMTX path never publishes reports healthy forever; node looks alive while recording nothing (H9). | Live fake wrapper process + stub `/v3/paths/get` returning `ready:false`; pre-fix `monitor_streams` never restarts. | Deep readiness probe: path not-ready for `DEEP_HEALTH_MAX_STRIKES` consecutive runs → restart within the cron budget; API-unreachable never strikes; ready resets the streak. | `test_deep_health_check.bats` (6) |
+| D2 | HIGH | stream-manager ×4, metrics ×1 | Readiness parsed by grepping `"ready":true`, a field MediaMTX **deprecated** in favour of `available` → a future server dropping `ready` makes every stream read dead / every ready count 0. | Stub API returning the new `{"available":true}` shape; pre-fix `path_is_ready`/`count_ready`/`validate_stream`/metrics all fail. | Tolerant parser accepting both shapes, preferring the new field, centralised in `mediamtx_json_*`. | `test_mediamtx_json_compat.bats` (12) |
+| D3 | HIGH | stream-manager wrapper + cron budget + silence | Backoff run-time, cron restart budget and silence tracking used wall-clock `date +%s` → an NTP step on an RTC-less Pi makes a healthy multi-hour run measure negative (counted as a failure until the wrapper gives up), ages the restart budget out (anti-storm brake evaporates), and turns minutes of silence into a false DEAD MIC. | PATH-shim `date` jumping ±5000s / ±2h between calls; pre-fix 3 of 4 assertions fail. | All boot-scoped timers read `/proc/uptime` (monotonic); state lives under `/run` (cleared at boot). | `test_monotonic_timing.bats` (4) |
+
+**New findings (same failure classes, new instances):**
+
+| # | Sev | Component | Failure (state → wrong outcome) | Repro | Fix | Test |
+|---|-----|-----------|---------------------------------|-------|-----|------|
+| N1 | HIGH | stream-manager API counts | `count=$(echo "$json" \| grep -o … \| wc -l)` under pipefail → an **idle** server (0 ready paths / 0 sessions) aborts `mediamtx_count_ready_paths`, `_count_rtsp_sessions`, `_count_all_connections`, `get_status_summary` mid-run. | Stub API with empty item lists; pre-fix each function exits non-zero. | Centralised `_json_count_matches` that never fails. | in `test_mediamtx_json_compat.bats` |
+| N2 | HIGH | 7 scripts, 15 sites | `var=$(cmd \| grep PAT \| …)` under `set -euo pipefail` aborts the whole run when grep matches nothing — even though the next line handles the empty result (NTP probe on an unsynced daemon, audio-level check with no volumedetect output, metrics scrape when MediaMTX exits mid-scrape → stale `.prom`, checksum verify, service-env merge, …). | Per-function fakes driving each into its empty-match path; pre-fix 8 of 11 abort. | `|| true` / explicit `|| default` guards preserving the intended fallback. | `test_pipefail_aborts.bats` (11) |
+| N3 | CRITICAL | stream-manager `load_device_config` | Device config `source`d directly → a config truncated by power loss / SD-card bit-rot / a bad operator edit hits a syntax error that aborts `start` under errexit; **no streams come up** on the next unattended boot — total outage from one bad line. | Truncated (unterminated-array) config; pre-fix `load_device_config` exits 2, `start` aborts. | `bash -n` validate before sourcing → ignore & use defaults if corrupt; source valid config with errexit neutralised (restored after). | `test_config_crash_safety.bats` (4) |
+| N4 | HIGH | stream-manager numeric env | Any non-numeric override of a numeric knob (e.g. `CRON_RESTART_MAX_PER_HOUR=unlimited`) reaches bash arithmetic → `set -u` "unbound variable" kills **every cron monitor pass**. | Sourcing with `CRON_RESTART_MAX_PER_HOUR=unlimited` then calling `should_restart_stream`; pre-fix aborts. | 37 knobs coerced (base-10, sane default on garbage) at load; valid overrides preserved. | `test_numeric_env_hardening.bats` (5) |
+| N5 | HIGH | storage retention | `find -mtime +N` after an NTP step sees minutes-old recordings (written with a 1970 clock) as ~56 years old → **mass-deletes fresh data**. | `touch -d @1000000` recording + real retention run; pre-fix it is deleted. | Skip age-based cleanup while the clock is pre-`CLOCK_SANE_EPOCH`; keep any file with a pre-epoch mtime; emergency size cleanup exempt (proven). | `test_storage_clock_sanity.bats` (4) |
+| N6 | HIGH | storage monitoring | Only block usage was checked → a recorder exhausting **inodes** (many small files) fails every write with ENOSPC while monitoring reports "OK"; no cleanup runs. | Stub `df` with 40% blocks / 99% inodes; pre-fix `cmd_monitor` stays quiet. | `df -Pi` inode usage subject to the same warn/critical/emergency thresholds; unknown accounting = no pressure. | `test_storage_inodes.bats` (4) |
+| N7 | MEDIUM | metrics | A `.prom` left by a dead exporter is indistinguishable from a live one → "dead recorder looks alive". | — (feature gap). | Emit `lyrebird_scrape_timestamp_seconds`; alert on age. | in `test_lyrebird_metrics.bats` |
+
+**Still deferred (one line each, with the specific blocker):**
+- MediaMTX supported-version string is already at `v1.19.x` in-code and the
+  installer fetches versions dynamically, so there is no hardcoded pin left to
+  bump; a live-server integration test against a real v1.19.x control API
+  remains out of reach without a running MediaMTX.
+- Silence/dead-mic **detection thresholds** (dB, durations) are validated for
+  clock-safety and abort-safety here but not for acoustic accuracy — that needs
+  a real microphone and is left to field calibration.

--- a/install_mediamtx.sh
+++ b/install_mediamtx.sh
@@ -661,7 +661,7 @@ verify_checksum() {
 
     # Extract checksum
     local expected_checksum
-    expected_checksum=$(grep -F "${filename}" "${checksum_file}" 2>/dev/null | head -1 | awk '{print $1}')
+    expected_checksum=$(grep -F "${filename}" "${checksum_file}" 2>/dev/null | head -1 | awk '{print $1}') || true
 
     if [[ -z "${expected_checksum}" ]] || [[ ! "${expected_checksum}" =~ ^[a-f0-9]{64}$ ]]; then
         if [[ "${FORCE_MODE}" == "true" ]]; then
@@ -1296,7 +1296,7 @@ update_mediamtx() {
     # Get current version
     local current_version="unknown"
     if "${INSTALL_DIR}/mediamtx" --version &>/dev/null; then
-        current_version=$("${INSTALL_DIR}/mediamtx" --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        current_version=$("${INSTALL_DIR}/mediamtx" --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1) || current_version="unknown"
     fi
 
     # Get target version
@@ -1378,7 +1378,7 @@ update_mediamtx() {
     # Verify new version
     if "${INSTALL_DIR}/mediamtx" --version &>/dev/null; then
         local new_version
-        new_version=$("${INSTALL_DIR}/mediamtx" --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        new_version=$("${INSTALL_DIR}/mediamtx" --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1) || new_version="unknown"
         log_info "Updated to version: ${new_version}"
     fi
 
@@ -1609,7 +1609,7 @@ show_status() {
 
         local version="unknown"
         if "${INSTALL_DIR}/mediamtx" --version &>/dev/null; then
-            version=$("${INSTALL_DIR}/mediamtx" --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            version=$("${INSTALL_DIR}/mediamtx" --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1) || version="unknown"
         fi
         echo "Version: ${version}"
     else

--- a/lyrebird-diagnostics.sh
+++ b/lyrebird-diagnostics.sh
@@ -606,12 +606,12 @@ get_script_version() {
         return
     fi
 
-    version=$(grep -m1 "^readonly SCRIPT_VERSION=" "${script_path}" 2>/dev/null | cut -d'"' -f2)
+    version=$(grep -m1 "^readonly SCRIPT_VERSION=" "${script_path}" 2>/dev/null | cut -d'"' -f2) || true
     if [[ -z "${version}" ]]; then
-        version=$(grep -m1 "^SCRIPT_VERSION=" "${script_path}" 2>/dev/null | cut -d'"' -f2)
+        version=$(grep -m1 "^SCRIPT_VERSION=" "${script_path}" 2>/dev/null | cut -d'"' -f2) || true
     fi
     if [[ -z "${version}" ]]; then
-        version=$(grep -m1 "# Version:" "${script_path}" 2>/dev/null | awk '{print $3}')
+        version=$(grep -m1 "# Version:" "${script_path}" 2>/dev/null | awk '{print $3}') || true
     fi
 
     echo "${version:-unknown}"
@@ -1307,7 +1307,7 @@ get_fd_usage_percent() {
 
     local fd_limit
     if [[ -f "/proc/${pid}/limits" ]]; then
-        fd_limit=$(grep "Max open files" "/proc/${pid}/limits" 2>/dev/null | awk '{print $4}')
+        fd_limit=$(grep "Max open files" "/proc/${pid}/limits" 2>/dev/null | awk '{print $4}') || true
     fi
 
     # FIXED: Explicit zero-check guard
@@ -1395,7 +1395,7 @@ get_tcp_ephemeral_status() {
 get_ntp_offset_ms() {
     if command -v ntpq >/dev/null 2>&1; then
         local offset
-        offset=$(ntpq -p 2>/dev/null | grep -E '^\*|^o' | head -1 | awk '{print $(NF-2)}')
+        offset=$(ntpq -p 2>/dev/null | grep -E '^\*|^o' | head -1 | awk '{print $(NF-2)}') || true
 
         if [[ -n "${offset}" ]] && [[ "${offset}" =~ ^-?[0-9]+\. ]]; then
             echo "${offset}"
@@ -1404,7 +1404,7 @@ get_ntp_offset_ms() {
         fi
     elif command -v chronyc >/dev/null 2>&1; then
         local offset
-        offset=$(chronyc tracking 2>/dev/null | grep "Frequency offset" | awk '{print $(NF-1)}')
+        offset=$(chronyc tracking 2>/dev/null | grep "Frequency offset" | awk '{print $(NF-1)}') || true
 
         [[ -n "${offset}" ]] && echo "${offset}" || echo "unknown"
     else

--- a/lyrebird-metrics.sh
+++ b/lyrebird-metrics.sh
@@ -365,9 +365,14 @@ collect_api_metrics() {
             path_count=$(echo "$paths_json" | grep -o '"name"' | wc -l || true)
             emit_metric "api_paths_total" "$path_count" "Total paths registered in MediaMTX"
 
-            # Count ready paths
+            # Count ready paths. MediaMTX deprecated "ready" in favour of
+            # "available"; accept both shapes, preferring the new field.
             local ready_count
-            ready_count=$(echo "$paths_json" | grep -o '"ready":true' | wc -l || true)
+            if [[ "$paths_json" == *'"available":'* ]]; then
+                ready_count=$(echo "$paths_json" | grep -o '"available":true' | wc -l || true)
+            else
+                ready_count=$(echo "$paths_json" | grep -o '"ready":true' | wc -l || true)
+            fi
             emit_metric "api_paths_ready" "$ready_count" "Paths with ready status"
         fi
 

--- a/lyrebird-metrics.sh
+++ b/lyrebird-metrics.sh
@@ -121,7 +121,7 @@ collect_mediamtx_metrics() {
     # Check if MediaMTX is running
     if pgrep -f "mediamtx" >/dev/null 2>&1; then
         mediamtx_running=1
-        mediamtx_pid=$(pgrep -f "mediamtx" | head -1)
+        mediamtx_pid=$(pgrep -f "mediamtx" | head -1) || true
     fi
 
     emit_metric "mediamtx_up" "$mediamtx_running" "MediaMTX server running (1=up, 0=down)"

--- a/lyrebird-metrics.sh
+++ b/lyrebird-metrics.sh
@@ -20,11 +20,11 @@
 # Integration with node_exporter:
 #   ./lyrebird-metrics.sh --file /var/lib/node_exporter/textfile_collector/lyrebird.prom
 #
-# Version: 1.1.0 - Enhanced MediaMTX API metrics coverage
+# Version: 1.2.0 - Tolerant readiness parsing, in-band staleness timestamp
 
 set -euo pipefail
 
-readonly VERSION="1.1.0"
+readonly VERSION="1.2.0"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 readonly SCRIPT_NAME
 

--- a/lyrebird-metrics.sh
+++ b/lyrebird-metrics.sh
@@ -557,6 +557,13 @@ generate_all_metrics() {
     echo ""
 
     collect_stream_metrics || true
+    echo ""
+
+    # In-band staleness marker. A textfile .prom left behind by a dead exporter
+    # is otherwise indistinguishable from a live one -- the node "looks alive"
+    # while recording nothing. Alert on:
+    #   time() - lyrebird_scrape_timestamp_seconds > <2x scrape interval>
+    emit_metric "scrape_timestamp_seconds" "$(date +%s)" "Unix time this scrape was generated (alert when stale)"
 }
 
 # Simple HTTP server using netcat (for basic metrics serving)

--- a/lyrebird-orchestrator.sh
+++ b/lyrebird-orchestrator.sh
@@ -598,7 +598,7 @@ refresh_system_state() {
         else
             # Fallback: limit output before counting to prevent DoS
             # head -n 1001 ensures we never process more than 1001 PIDs
-            raw_count=$(pgrep -x ffmpeg 2>/dev/null | head -n 1001 | wc -l)
+            raw_count=$(pgrep -x ffmpeg 2>/dev/null | head -n 1001 | wc -l) || true
         fi
 
         # Validate count with overflow protection

--- a/lyrebird-storage.sh
+++ b/lyrebird-storage.sh
@@ -206,6 +206,18 @@ get_disk_usage() {
     printf '%s' "$out"
 }
 
+# Get inode usage percentage for a path (POSIX `df -Pi`). A recorder writing
+# many small files can exhaust INODES long before blocks: writes then fail
+# with ENOSPC while block-based monitoring still reports the disk "OK", so no
+# cleanup ever runs -- silent recording failure. Emits an empty string when
+# inode accounting is unavailable (e.g. btrfs reports "-"); callers treat that
+# as unknown, never as pressure.
+get_inode_usage() {
+    local path="${1:-/}" out=""
+    out=$(df -Pi "$path" 2>/dev/null | awk 'NR==2 {print $5}' | tr -cd '0-9') || out=""
+    printf '%s' "$out"
+}
+
 # Get free space in MB for a path (POSIX `df -Pk` → 1024-byte blocks).
 # Emits an empty string if df can't be parsed (caller treats as "unknown").
 get_free_space_mb() {
@@ -557,17 +569,26 @@ cmd_monitor() {
         return 0
     fi
 
-    log_debug "Disk usage: ${usage}%, free: ${free_mb}MB"
+    # Inode pressure counts as disk pressure: many small recordings exhaust
+    # inodes long before blocks, and every write then fails ENOSPC while the
+    # block percentage still looks healthy. Unknown ("-", unsupported fs) is
+    # treated as no pressure, never as an emergency.
+    local iusage
+    iusage=$(get_inode_usage "/")
+    [[ "$iusage" =~ ^[0-9]+$ ]] || iusage=0
 
-    if [[ $usage -ge $DISK_EMERGENCY_PERCENT ]] || [[ $free_mb -lt $MIN_FREE_SPACE_MB ]]; then
-        log_error "EMERGENCY: Disk ${usage}% full, ${free_mb}MB free"
+    log_debug "Disk usage: ${usage}%, inodes: ${iusage}%, free: ${free_mb}MB"
+
+    if [[ $usage -ge $DISK_EMERGENCY_PERCENT ]] || [[ $iusage -ge $DISK_EMERGENCY_PERCENT ]] \
+        || [[ $free_mb -lt $MIN_FREE_SPACE_MB ]]; then
+        log_error "EMERGENCY: Disk ${usage}% full, inodes ${iusage}% used, ${free_mb}MB free"
         emergency_cleanup
         cmd_cleanup
-    elif [[ $usage -ge $DISK_CRITICAL_PERCENT ]]; then
-        log_warn "CRITICAL: Disk ${usage}% full"
+    elif [[ $usage -ge $DISK_CRITICAL_PERCENT ]] || [[ $iusage -ge $DISK_CRITICAL_PERCENT ]]; then
+        log_warn "CRITICAL: Disk ${usage}% full, inodes ${iusage}% used"
         cmd_cleanup
-    elif [[ $usage -ge $DISK_WARNING_PERCENT ]]; then
-        log_warn "WARNING: Disk ${usage}% full"
+    elif [[ $usage -ge $DISK_WARNING_PERCENT ]] || [[ $iusage -ge $DISK_WARNING_PERCENT ]]; then
+        log_warn "WARNING: Disk ${usage}% full, inodes ${iusage}% used"
         cleanup_temp
         truncate_large_logs
     else

--- a/lyrebird-storage.sh
+++ b/lyrebird-storage.sh
@@ -73,6 +73,18 @@ readonly LOG_RETENTION_DAYS="$_log_ret"
 readonly TEMP_RETENTION_HOURS="$_tmp_ret"
 unset _rec_ret _log_ret _tmp_ret
 
+# Clock-sanity floor for age-based recording deletion. An RTC-less Pi boots
+# with its clock in 1970 until NTP syncs; recordings captured in that window
+# carry mtimes decades in the past, and the moment the clock steps to the real
+# date `find -mtime +N` sees minutes-old data as 56 years old and deletes it.
+# No recording can legitimately predate the project, so any mtime before this
+# epoch (default 2025-01-01) means "written with a broken clock, real age
+# unknown" -- age-based cleanup must keep it. Emergency size-based cleanup is
+# deliberately NOT gated on this: a full disk must still be freed.
+_clock_floor=$(_coerce_uint "${LYREBIRD_CLOCK_SANE_EPOCH:-1735689600}" 1735689600)
+readonly CLOCK_SANE_EPOCH="$_clock_floor"
+unset _clock_floor
+
 # Disk thresholds (percentage) - validate bounds 0-100
 _disk_warning=$(_coerce_uint "${DISK_WARNING_PERCENT:-80}" 80)
 _disk_critical=$(_coerce_uint "${DISK_CRITICAL_PERCENT:-90}" 90)
@@ -246,17 +258,39 @@ cleanup_recordings() {
         return 0
     fi
 
+    # With an unsynced clock every file age is meaningless -- defer age-based
+    # deletion until the clock is sane (the next cron run after NTP syncs).
+    local now_epoch
+    now_epoch=$(date +%s)
+    if [[ "$now_epoch" -lt "$CLOCK_SANE_EPOCH" ]]; then
+        log_warn "System clock ($now_epoch) predates ${CLOCK_SANE_EPOCH} (not yet NTP-synced?); skipping age-based recording cleanup"
+        return 0
+    fi
+
     local count=0
     local freed_bytes=0
+    local kept_broken_clock=0
 
     # Find and delete old recording files
     while IFS= read -r -d '' file; do
+        # A pre-CLOCK_SANE_EPOCH mtime means the file was written while the
+        # clock was broken; its real age is unknown and it may be minutes old.
+        local mtime
+        mtime=$(stat -c%Y "$file" 2>/dev/null || echo 0)
+        if [[ "$mtime" -lt "$CLOCK_SANE_EPOCH" ]]; then
+            ((++kept_broken_clock))
+            continue
+        fi
         local size
         size=$(stat -c%s "$file" 2>/dev/null || echo 0)
         safe_delete "$file" "recording"
         ((++count))
         freed_bytes=$((freed_bytes + size))
     done < <(find "$RECORDING_DIR" -type f \( -name "*.wav" -o -name "*.mp3" -o -name "*.flac" -o -name "*.opus" -o -name "*.ogg" \) -mtime "+${RECORDING_RETENTION_DAYS}" -print0 2>/dev/null)
+
+    if [[ $kept_broken_clock -gt 0 ]]; then
+        log_warn "Kept $kept_broken_clock recording(s) with pre-${CLOCK_SANE_EPOCH} mtimes (written before NTP sync; real age unknown)"
+    fi
 
     # Remove empty SUBdirectories. `-mindepth 1` is essential: without it, once
     # retention removes the last recordings, find would delete "$RECORDING_DIR"

--- a/lyrebird-storage.sh
+++ b/lyrebird-storage.sh
@@ -22,11 +22,11 @@
 #   # Hourly monitoring
 #   0 * * * * /usr/local/bin/lyrebird-storage.sh monitor
 #
-# Version: 1.0.0
+# Version: 1.1.0 - Broken-clock retention guard + inode-exhaustion detection
 
 set -euo pipefail
 
-readonly VERSION="1.0.0"
+readonly VERSION="1.1.0"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 readonly SCRIPT_NAME
 

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -1767,12 +1767,47 @@ mediamtx_get_path() {
     mediamtx_api_call GET "/paths/get/${path_name}"
 }
 
+# --- Tolerant JSON status parsing -------------------------------------------
+# MediaMTX deprecated the path "ready"/"bytesReceived"/"tracks" fields in favour
+# of "available"/"inboundBytes"/"tracks2" (still emitting both as of v1.19.x).
+# These helpers accept BOTH shapes so a future MediaMTX that drops "ready" does
+# not make every stream look dead. When both fields are present the NEW field
+# wins. They are also safe under set -euo pipefail: a zero-match grep must not
+# abort the caller (pipefail turns "0 ready paths" into exit 1 otherwise).
+
+# Count occurrences of a fixed pattern in a JSON blob; never fails, prints >= 0.
+_json_count_matches() {
+    local json="$1" pattern="$2" count
+    count=$(printf '%s' "$json" | grep -o "$pattern" | wc -l) || count=0
+    printf '%s' "${count:-0}"
+}
+
+# Is a single path's JSON "ready"? Tolerates deprecated and current shapes.
+mediamtx_json_path_ready() {
+    local json="$1"
+    if [[ "$json" == *'"available":'* ]]; then
+        [[ "$json" == *'"available":true'* ]]
+    else
+        [[ "$json" == *'"ready":true'* ]]
+    fi
+}
+
+# Count ready paths in a /v3/paths/list response, tolerant of both shapes.
+mediamtx_json_count_ready() {
+    local json="$1"
+    if [[ "$json" == *'"available":'* ]]; then
+        _json_count_matches "$json" '"available":true'
+    else
+        _json_count_matches "$json" '"ready":true'
+    fi
+}
+
 # Check if a path is ready (streaming)
 mediamtx_path_is_ready() {
     local path_name="$1"
     local path_info
     path_info=$(mediamtx_get_path "$path_name") || return 1
-    echo "$path_info" | grep -q '"ready":true'
+    mediamtx_json_path_ready "$path_info"
 }
 
 # -----------------------------------------------------------------------------
@@ -2017,7 +2052,7 @@ mediamtx_count_rtsp_sessions() {
     local sessions
     sessions=$(mediamtx_list_rtsp_sessions) || { echo "0"; return; }
     local count
-    count=$(echo "$sessions" | grep -o '"id"' | wc -l)
+    count=$(_json_count_matches "$sessions" '"id"')
     echo "${count:-0}"
 }
 
@@ -2033,25 +2068,25 @@ mediamtx_count_all_connections() {
     # RTSPS sessions
     local rtsps
     rtsps=$(mediamtx_list_rtsps_sessions 2>/dev/null) || rtsps=""
-    count=$(echo "$rtsps" | grep -o '"id"' | wc -l)
+    count=$(_json_count_matches "$rtsps" '"id"')
     total=$((total + count))
 
     # RTMP connections
     local rtmp
     rtmp=$(mediamtx_list_rtmp_conns 2>/dev/null) || rtmp=""
-    count=$(echo "$rtmp" | grep -o '"id"' | wc -l)
+    count=$(_json_count_matches "$rtmp" '"id"')
     total=$((total + count))
 
     # WebRTC sessions
     local webrtc
     webrtc=$(mediamtx_list_webrtc_sessions 2>/dev/null) || webrtc=""
-    count=$(echo "$webrtc" | grep -o '"id"' | wc -l)
+    count=$(_json_count_matches "$webrtc" '"id"')
     total=$((total + count))
 
     # SRT connections
     local srt
     srt=$(mediamtx_list_srt_conns 2>/dev/null) || srt=""
-    count=$(echo "$srt" | grep -o '"id"' | wc -l)
+    count=$(_json_count_matches "$srt" '"id"')
     total=$((total + count))
 
     echo "$total"
@@ -2062,7 +2097,7 @@ mediamtx_count_ready_paths() {
     local paths
     paths=$(mediamtx_list_paths) || { echo "0"; return; }
     local count
-    count=$(echo "$paths" | grep -o '"ready":true' | wc -l)
+    count=$(mediamtx_json_count_ready "$paths")
     echo "${count:-0}"
 }
 
@@ -2095,9 +2130,9 @@ mediamtx_get_status_summary() {
     local paths_json
     paths_json=$(mediamtx_list_paths 2>/dev/null) || paths_json=""
     local total_paths
-    total_paths=$(echo "$paths_json" | grep -o '"name"' | wc -l)
+    total_paths=$(_json_count_matches "$paths_json" '"name"')
     local ready_paths
-    ready_paths=$(echo "$paths_json" | grep -o '"ready":true' | wc -l)
+    ready_paths=$(mediamtx_json_count_ready "$paths_json")
 
     local rtsp_sessions
     rtsp_sessions=$(mediamtx_count_rtsp_sessions 2>/dev/null)
@@ -2767,7 +2802,7 @@ validate_stream() {
             local api_base api_response
             api_base=$(detect_mediamtx_api_version)
             local api_url="${api_base}/paths/get/${stream_path}"
-            if api_response=$(curl -s --max-time 2 "${api_url}" 2>/dev/null) && [[ "$api_response" == *'"ready":true'* ]]; then
+            if api_response=$(curl -s --max-time 2 "${api_url}" 2>/dev/null) && mediamtx_json_path_ready "$api_response"; then
                 log DEBUG "Stream $stream_path validated via API (attempt ${attempt})"
                 return 0
             fi

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -197,7 +197,7 @@ unset _LYREBIRD_COMMON _LYREBIRD_COMMON_EXPECTED_HASH
 unset -f _verify_common_library
 
 # Constants
-readonly VERSION="1.4.3"
+readonly VERSION="1.5.0"
 
 # Script identification
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
@@ -428,7 +428,7 @@ readonly USB_DISCONNECT_GRACE_PERIOD
 # Version compatibility
 readonly MIN_COMPATIBLE_COMMON_VERSION="1.0.0"
 # shellcheck disable=SC2034 # SCRIPT_COMPAT_VERSION exported for external version checking tools
-readonly SCRIPT_COMPAT_VERSION="1.4.3"
+readonly SCRIPT_COMPAT_VERSION="1.5.0"
 
 # Standard timing constants
 readonly QUICK_SLEEP=0.1

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -2135,7 +2135,7 @@ mediamtx_get_status_summary() {
     }
 
     local version
-    version=$(echo "$info" | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
+    version=$(echo "$info" | grep -o '"version":"[^"]*"' | cut -d'"' -f4) || true
 
     local paths_json
     paths_json=$(mediamtx_list_paths 2>/dev/null) || paths_json=""
@@ -2223,7 +2223,7 @@ check_audio_level() {
 
     # Parse max volume from output (format: "max_volume: -XX.X dB")
     local max_volume
-    max_volume=$(echo "$ffmpeg_output" | grep -o "max_volume: [0-9.-]*" | grep -o "[0-9.-]*" | head -1)
+    max_volume=$(echo "$ffmpeg_output" | grep -o "max_volume: [0-9.-]*" | grep -o "[0-9.-]*" | head -1) || true
 
     if [[ -z "$max_volume" ]]; then
         log DEBUG "Could not parse audio level for $stream_name"

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -302,6 +302,16 @@ readonly MEDIAMTX_LOG_MAX_SIZE="${MEDIAMTX_LOG_MAX_SIZE:-52428800}" # 50MB
 readonly CRON_RESTART_MAX_PER_HOUR="${CRON_RESTART_MAX_PER_HOUR:-6}"
 readonly CRON_RESTART_STATE_DIR="${CRON_RESTART_STATE_DIR:-/run/lyrebird/cron-restarts}"
 
+# Deep health probe (H9): a live wrapper PID does not prove audio is flowing --
+# the wrapper may sit in endless backoff, or FFmpeg may hang with the path
+# never publishing. When the MediaMTX control API is reachable, monitor also
+# asks it whether each path is actually ready; a stream that stays not-ready
+# for DEEP_HEALTH_MAX_STRIKES consecutive monitor runs is restarted. Strikes
+# live in /run (reset at boot). API-unreachable never strikes a stream.
+readonly DEEP_HEALTH_CHECK_ENABLED="${DEEP_HEALTH_CHECK_ENABLED:-true}"
+readonly DEEP_HEALTH_MAX_STRIKES="${DEEP_HEALTH_MAX_STRIKES:-3}"
+readonly DEEP_HEALTH_STATE_DIR="${DEEP_HEALTH_STATE_DIR:-/run/lyrebird/deep-health}"
+
 # Watchdog/Heartbeat settings
 # Heartbeat runs more frequently than cron for faster failure detection
 readonly HEARTBEAT_INTERVAL="${HEARTBEAT_INTERVAL:-30}"             # Seconds between heartbeats
@@ -2556,6 +2566,73 @@ should_restart_stream() {
     return 1
 }
 
+# --- Deep health probe (H9) --------------------------------------------------
+# Ask the MediaMTX control API whether a path is actually publishing.
+# Returns: 0 = ready, 1 = not ready, 2 = unknown (curl absent/API unreachable).
+probe_stream_ready() {
+    local stream_path="$1"
+    command_exists curl || return 2
+    local api_base response
+    api_base=$(detect_mediamtx_api_version)
+    if ! response=$(curl -s --max-time 3 "${api_base}/paths/get/${stream_path}" 2>/dev/null) \
+        || [[ -z "$response" ]]; then
+        return 2
+    fi
+    if mediamtx_json_path_ready "$response"; then
+        return 0
+    fi
+    return 1
+}
+
+# Record a probe verdict for a stream. Not-ready increments a strike counter;
+# ready clears it; unknown leaves it untouched (an API blip must neither strike
+# a healthy stream nor forgive a stuck one). Returns 0 when the stream has been
+# not-ready for DEEP_HEALTH_MAX_STRIKES consecutive checks (caller restarts it,
+# counter resets so the next escalation needs a fresh streak).
+deep_health_note() {
+    local stream_path="$1" verdict="$2"
+    local strike_file="${DEEP_HEALTH_STATE_DIR}/${stream_path}.strikes"
+    case "$verdict" in
+        ready)
+            rm -f "$strike_file" 2>/dev/null || true
+            return 1
+            ;;
+        unknown)
+            return 1
+            ;;
+    esac
+    mkdir -p "${DEEP_HEALTH_STATE_DIR}" 2>/dev/null || true
+    local strikes=0
+    if [[ -f "$strike_file" ]]; then
+        strikes=$(cat "$strike_file" 2>/dev/null) || strikes=0
+    fi
+    [[ "$strikes" =~ ^[0-9]+$ ]] || strikes=0
+    strikes=$((strikes + 1))
+    printf '%s\n' "$strikes" >"$strike_file" 2>/dev/null || true
+    if ((strikes >= DEEP_HEALTH_MAX_STRIKES)); then
+        rm -f "$strike_file" 2>/dev/null || true
+        return 0
+    fi
+    log INFO "Stream $stream_path: wrapper alive but path not ready (strike ${strikes}/${DEEP_HEALTH_MAX_STRIKES})"
+    return 1
+}
+
+# Combined probe: 0 => the stream is confirmed stuck (alive wrapper, path
+# continuously not-ready) and should be restarted; 1 => leave it alone.
+deep_stream_unhealthy() {
+    local stream_path="$1"
+    [[ "${DEEP_HEALTH_CHECK_ENABLED}" == "true" ]] || return 1
+    local rc=0
+    probe_stream_ready "$stream_path" || rc=$?
+    local verdict
+    case "$rc" in
+        0) verdict="ready" ;;
+        1) verdict="notready" ;;
+        *) verdict="unknown" ;;
+    esac
+    deep_health_note "$stream_path" "$verdict"
+}
+
 # Stream health monitoring with automatic restart
 monitor_streams() {
     log INFO "Checking stream health..."
@@ -2655,6 +2732,24 @@ monitor_streams() {
                     ((streams_failed++)) || true
                     log WARN "Multiplex stream $stream_path PID $pid is stale (cron mode: not restarting)"
                 fi
+            elif deep_stream_unhealthy "$stream_path"; then
+                # Wrapper alive but the path has been continuously not-ready:
+                # a hung FFmpeg or endless backoff. Restart within the budget.
+                if should_restart_stream "$stream_path"; then
+                    log WARN "Multiplex stream $stream_path wrapper is alive but path is not ready - restarting"
+                    terminate_process_group "$pid" 5 || true
+                    rm -f "$pid_file"
+                    if start_ffmpeg_multiplex_stream "${devices[@]}"; then
+                        ((streams_restarted++)) || true
+                        log INFO "Successfully restarted multiplex stream $stream_path"
+                    else
+                        ((streams_failed++)) || true
+                        log ERROR "Failed to restart multiplex stream $stream_path"
+                    fi
+                else
+                    ((streams_failed++)) || true
+                    log WARN "Multiplex stream $stream_path is not ready (restart budget exhausted)"
+                fi
             else
                 ((streams_healthy++)) || true
                 log DEBUG "Multiplex stream $stream_path is healthy (PID: $pid)"
@@ -2747,6 +2842,33 @@ monitor_streams() {
                 else
                     ((streams_failed++)) || true
                     log WARN "Stream $stream_path PID $pid is stale (cron mode: not restarting)"
+                fi
+                continue
+            fi
+
+            # Wrapper PID alive: shallow-healthy. Deep probe (H9): a path that
+            # stays not-ready across consecutive checks while its wrapper is
+            # alive is a hung FFmpeg or endless backoff -- restart it.
+            if deep_stream_unhealthy "$stream_path"; then
+                if should_restart_stream "$stream_path"; then
+                    if ! check_alsa_device_available "$card_num"; then
+                        log WARN "Stream $stream_path: ALSA device not available (card $card_num), skipping restart"
+                        ((streams_failed++)) || true
+                        continue
+                    fi
+                    log WARN "Stream $stream_path wrapper (PID $pid) is alive but path is not ready - restarting"
+                    terminate_process_group "$pid" 5 || true
+                    rm -f "$pid_file"
+                    if start_ffmpeg_stream "$device_name" "$card_num" "$stream_path"; then
+                        ((streams_restarted++)) || true
+                        log INFO "Successfully restarted stream $stream_path"
+                    else
+                        ((streams_failed++)) || true
+                        log ERROR "Failed to restart stream $stream_path"
+                    fi
+                else
+                    ((streams_failed++)) || true
+                    log WARN "Stream $stream_path is not ready (restart budget exhausted)"
                 fi
                 continue
             fi

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -265,30 +265,71 @@ readonly MAX_STREAM_NAME_LENGTH=48
 readonly MIN_STREAM_NAME_LENGTH=1
 readonly RESERVED_STREAM_NAMES="control|stats|api|metrics|health"
 
+# Coerce an env override to a non-negative base-10 integer, falling back to
+# the default when the value is not all digits. A non-numeric value (e.g.
+# CRON_RESTART_MAX_PER_HOUR=unlimited) otherwise reaches arithmetic evaluation
+# later and ABORTS the whole run under set -e -- silently killing every cron
+# monitor pass. Base-10 also stops 08/09 being misread as invalid octal.
+_uint_or() {
+    local value="${1:-}" default="$2"
+    if [[ "$value" =~ ^[0-9]+$ ]]; then
+        printf '%s' "$((10#$value))"
+    else
+        printf '%s' "$default"
+    fi
+}
+
+# Same, for integers that may carry a leading minus sign (dB thresholds).
+_int_or() {
+    local value="${1:-}" default="$2"
+    if [[ "$value" =~ ^-?[0-9]+$ ]]; then
+        printf '%s' "$value"
+    else
+        printf '%s' "$default"
+    fi
+}
+
 # Timing settings
-readonly STREAM_STARTUP_DELAY="${STREAM_STARTUP_DELAY:-10}"
-readonly STREAM_VALIDATION_ATTEMPTS="${STREAM_VALIDATION_ATTEMPTS:-3}"
-readonly STREAM_VALIDATION_DELAY="${STREAM_VALIDATION_DELAY:-5}"
-readonly USB_STABILIZATION_DELAY="${USB_STABILIZATION_DELAY:-5}"
-readonly RESTART_STABILIZATION_DELAY="${RESTART_STABILIZATION_DELAY:-15}"
+STREAM_STARTUP_DELAY=$(_uint_or "${STREAM_STARTUP_DELAY:-}" 10)
+readonly STREAM_STARTUP_DELAY
+STREAM_VALIDATION_ATTEMPTS=$(_uint_or "${STREAM_VALIDATION_ATTEMPTS:-}" 3)
+readonly STREAM_VALIDATION_ATTEMPTS
+STREAM_VALIDATION_DELAY=$(_uint_or "${STREAM_VALIDATION_DELAY:-}" 5)
+readonly STREAM_VALIDATION_DELAY
+USB_STABILIZATION_DELAY=$(_uint_or "${USB_STABILIZATION_DELAY:-}" 5)
+readonly USB_STABILIZATION_DELAY
+RESTART_STABILIZATION_DELAY=$(_uint_or "${RESTART_STABILIZATION_DELAY:-}" 15)
+readonly RESTART_STABILIZATION_DELAY
 
 # Resource monitoring thresholds
-readonly MAX_FD_WARNING="${MAX_FD_WARNING:-500}"
-readonly MAX_FD_CRITICAL="${MAX_FD_CRITICAL:-1000}"
-readonly MAX_CPU_WARNING="${MAX_CPU_WARNING:-20}"
-readonly MAX_CPU_CRITICAL="${MAX_CPU_CRITICAL:-40}"
-readonly MAX_WRAPPER_RESTARTS="${MAX_WRAPPER_RESTARTS:-50}"
-readonly WRAPPER_SUCCESS_DURATION="${WRAPPER_SUCCESS_DURATION:-300}"
+MAX_FD_WARNING=$(_uint_or "${MAX_FD_WARNING:-}" 500)
+readonly MAX_FD_WARNING
+MAX_FD_CRITICAL=$(_uint_or "${MAX_FD_CRITICAL:-}" 1000)
+readonly MAX_FD_CRITICAL
+MAX_CPU_WARNING=$(_uint_or "${MAX_CPU_WARNING:-}" 20)
+readonly MAX_CPU_WARNING
+MAX_CPU_CRITICAL=$(_uint_or "${MAX_CPU_CRITICAL:-}" 40)
+readonly MAX_CPU_CRITICAL
+MAX_WRAPPER_RESTARTS=$(_uint_or "${MAX_WRAPPER_RESTARTS:-}" 50)
+readonly MAX_WRAPPER_RESTARTS
+WRAPPER_SUCCESS_DURATION=$(_uint_or "${WRAPPER_SUCCESS_DURATION:-}" 300)
+readonly WRAPPER_SUCCESS_DURATION
 
 # Wrapper restart behavior (extracted from hardcoded values)
-readonly MAX_CONSECUTIVE_FAILURES="${MAX_CONSECUTIVE_FAILURES:-5}"
-readonly INITIAL_RESTART_DELAY="${INITIAL_RESTART_DELAY:-10}"
-readonly MAX_RESTART_DELAY="${MAX_RESTART_DELAY:-300}"
+MAX_CONSECUTIVE_FAILURES=$(_uint_or "${MAX_CONSECUTIVE_FAILURES:-}" 5)
+readonly MAX_CONSECUTIVE_FAILURES
+INITIAL_RESTART_DELAY=$(_uint_or "${INITIAL_RESTART_DELAY:-}" 10)
+readonly INITIAL_RESTART_DELAY
+MAX_RESTART_DELAY=$(_uint_or "${MAX_RESTART_DELAY:-}" 300)
+readonly MAX_RESTART_DELAY
 
 # Log rotation settings
-readonly MAIN_LOG_MAX_SIZE="${MAIN_LOG_MAX_SIZE:-104857600}"        # 100MB
-readonly FFMPEG_LOG_MAX_SIZE="${FFMPEG_LOG_MAX_SIZE:-10485760}"     # 10MB
-readonly MEDIAMTX_LOG_MAX_SIZE="${MEDIAMTX_LOG_MAX_SIZE:-52428800}" # 50MB
+MAIN_LOG_MAX_SIZE=$(_uint_or "${MAIN_LOG_MAX_SIZE:-}" 104857600)        # 100MB
+readonly MAIN_LOG_MAX_SIZE
+FFMPEG_LOG_MAX_SIZE=$(_uint_or "${FFMPEG_LOG_MAX_SIZE:-}" 10485760)     # 10MB
+readonly FFMPEG_LOG_MAX_SIZE
+MEDIAMTX_LOG_MAX_SIZE=$(_uint_or "${MEDIAMTX_LOG_MAX_SIZE:-}" 52428800) # 50MB
+readonly MEDIAMTX_LOG_MAX_SIZE
 
 # ============================================================================
 # Production Reliability Settings (v1.4.2 additions)
@@ -299,7 +340,8 @@ readonly MEDIAMTX_LOG_MAX_SIZE="${MEDIAMTX_LOG_MAX_SIZE:-52428800}" # 50MB
 # repeated failures) MUST be brought back under cron, or it stays down forever on
 # an unattended box (H8). The cap prevents a persistently-failing stream from
 # being restarted every 5 minutes indefinitely (a restart storm).
-readonly CRON_RESTART_MAX_PER_HOUR="${CRON_RESTART_MAX_PER_HOUR:-6}"
+CRON_RESTART_MAX_PER_HOUR=$(_uint_or "${CRON_RESTART_MAX_PER_HOUR:-}" 6)
+readonly CRON_RESTART_MAX_PER_HOUR
 readonly CRON_RESTART_STATE_DIR="${CRON_RESTART_STATE_DIR:-/run/lyrebird/cron-restarts}"
 
 # Deep health probe (H9): a live wrapper PID does not prove audio is flowing --
@@ -309,52 +351,70 @@ readonly CRON_RESTART_STATE_DIR="${CRON_RESTART_STATE_DIR:-/run/lyrebird/cron-re
 # for DEEP_HEALTH_MAX_STRIKES consecutive monitor runs is restarted. Strikes
 # live in /run (reset at boot). API-unreachable never strikes a stream.
 readonly DEEP_HEALTH_CHECK_ENABLED="${DEEP_HEALTH_CHECK_ENABLED:-true}"
-readonly DEEP_HEALTH_MAX_STRIKES="${DEEP_HEALTH_MAX_STRIKES:-3}"
+DEEP_HEALTH_MAX_STRIKES=$(_uint_or "${DEEP_HEALTH_MAX_STRIKES:-}" 3)
+readonly DEEP_HEALTH_MAX_STRIKES
 readonly DEEP_HEALTH_STATE_DIR="${DEEP_HEALTH_STATE_DIR:-/run/lyrebird/deep-health}"
 
 # Watchdog/Heartbeat settings
 # Heartbeat runs more frequently than cron for faster failure detection
-readonly HEARTBEAT_INTERVAL="${HEARTBEAT_INTERVAL:-30}"             # Seconds between heartbeats
+HEARTBEAT_INTERVAL=$(_uint_or "${HEARTBEAT_INTERVAL:-}" 30)             # Seconds between heartbeats
+readonly HEARTBEAT_INTERVAL
 readonly HEARTBEAT_FILE="${HEARTBEAT_FILE:-/run/mediamtx-audio.heartbeat}"
 readonly ENABLE_HARDWARE_WATCHDOG="${ENABLE_HARDWARE_WATCHDOG:-auto}" # auto, yes, no
 readonly HARDWARE_WATCHDOG_DEVICE="${HARDWARE_WATCHDOG_DEVICE:-/dev/watchdog}"
-readonly HARDWARE_WATCHDOG_TIMEOUT="${HARDWARE_WATCHDOG_TIMEOUT:-60}" # Seconds
+HARDWARE_WATCHDOG_TIMEOUT=$(_uint_or "${HARDWARE_WATCHDOG_TIMEOUT:-}" 60) # Seconds
+readonly HARDWARE_WATCHDOG_TIMEOUT
 
 # Disk space monitoring thresholds
-readonly DISK_SPACE_WARNING_PERCENT="${DISK_SPACE_WARNING_PERCENT:-80}"
-readonly DISK_SPACE_CRITICAL_PERCENT="${DISK_SPACE_CRITICAL_PERCENT:-95}"
-readonly DISK_SPACE_MIN_FREE_MB="${DISK_SPACE_MIN_FREE_MB:-100}"    # Minimum free MB
+DISK_SPACE_WARNING_PERCENT=$(_uint_or "${DISK_SPACE_WARNING_PERCENT:-}" 80)
+readonly DISK_SPACE_WARNING_PERCENT
+DISK_SPACE_CRITICAL_PERCENT=$(_uint_or "${DISK_SPACE_CRITICAL_PERCENT:-}" 95)
+readonly DISK_SPACE_CRITICAL_PERCENT
+DISK_SPACE_MIN_FREE_MB=$(_uint_or "${DISK_SPACE_MIN_FREE_MB:-}" 100)    # Minimum free MB
+readonly DISK_SPACE_MIN_FREE_MB
 
 # Memory monitoring and leak detection
-readonly MEM_WARNING_PERCENT="${MEM_WARNING_PERCENT:-80}"
-readonly MEM_CRITICAL_PERCENT="${MEM_CRITICAL_PERCENT:-95}"
-readonly MEM_GROWTH_THRESHOLD_MB="${MEM_GROWTH_THRESHOLD_MB:-100}"  # MB growth triggers restart
+MEM_WARNING_PERCENT=$(_uint_or "${MEM_WARNING_PERCENT:-}" 80)
+readonly MEM_WARNING_PERCENT
+MEM_CRITICAL_PERCENT=$(_uint_or "${MEM_CRITICAL_PERCENT:-}" 95)
+readonly MEM_CRITICAL_PERCENT
+MEM_GROWTH_THRESHOLD_MB=$(_uint_or "${MEM_GROWTH_THRESHOLD_MB:-}" 100)  # MB growth triggers restart
+readonly MEM_GROWTH_THRESHOLD_MB
 readonly MEM_SAMPLE_FILE="${MEM_SAMPLE_FILE:-/var/lib/mediamtx-ffmpeg/.mem_samples}"
 
 # Network connectivity monitoring
 readonly NETWORK_CHECK_ENABLED="${NETWORK_CHECK_ENABLED:-true}"
 readonly NETWORK_CHECK_TARGET="${NETWORK_CHECK_TARGET:-gateway}"    # gateway, specific IP, or hostname
-readonly NETWORK_CHECK_TIMEOUT="${NETWORK_CHECK_TIMEOUT:-5}"        # Seconds
-readonly NETWORK_FAIL_THRESHOLD="${NETWORK_FAIL_THRESHOLD:-3}"      # Consecutive failures before alert
+NETWORK_CHECK_TIMEOUT=$(_uint_or "${NETWORK_CHECK_TIMEOUT:-}" 5)        # Seconds
+readonly NETWORK_CHECK_TIMEOUT
+NETWORK_FAIL_THRESHOLD=$(_uint_or "${NETWORK_FAIL_THRESHOLD:-}" 3)      # Consecutive failures before alert
+readonly NETWORK_FAIL_THRESHOLD
 
 # Audio buffering (memory-based with optional disk persistence)
 # Memory buffering is done via FFmpeg's rtbufsize option (no SD card wear)
 readonly AUDIO_BUFFER_ENABLED="${AUDIO_BUFFER_ENABLED:-true}"       # Enable enhanced memory buffering
-readonly AUDIO_BUFFER_SIZE_MB="${AUDIO_BUFFER_SIZE_MB:-64}"         # Memory buffer size per stream (MB)
-readonly AUDIO_RTBUFSIZE="${AUDIO_RTBUFSIZE:-33554432}"             # Real-time buffer size in bytes (32MB default)
+AUDIO_BUFFER_SIZE_MB=$(_uint_or "${AUDIO_BUFFER_SIZE_MB:-}" 64)         # Memory buffer size per stream (MB)
+readonly AUDIO_BUFFER_SIZE_MB
+AUDIO_RTBUFSIZE=$(_uint_or "${AUDIO_RTBUFSIZE:-}" 33554432)             # Real-time buffer size in bytes (32MB default)
+readonly AUDIO_RTBUFSIZE
 # Local recording (ring buffer) - writes audio to tmpfs or disk alongside streaming
 readonly AUDIO_LOCAL_RECORDING="${AUDIO_LOCAL_RECORDING:-false}"    # Enable local recording backup
 readonly AUDIO_RECORDING_PATH="${AUDIO_RECORDING_PATH:-/dev/shm/lyrebird-buffer}" # Default to tmpfs (RAM)
-readonly AUDIO_RECORDING_SEGMENT_TIME="${AUDIO_RECORDING_SEGMENT_TIME:-300}" # 5 min segments
-readonly AUDIO_RECORDING_SEGMENTS="${AUDIO_RECORDING_SEGMENTS:-12}" # Keep last 12 segments (1 hour)
+AUDIO_RECORDING_SEGMENT_TIME=$(_uint_or "${AUDIO_RECORDING_SEGMENT_TIME:-}" 300) # 5 min segments
+readonly AUDIO_RECORDING_SEGMENT_TIME
+AUDIO_RECORDING_SEGMENTS=$(_uint_or "${AUDIO_RECORDING_SEGMENTS:-}" 12) # Keep last 12 segments (1 hour)
+readonly AUDIO_RECORDING_SEGMENTS
 readonly AUDIO_DISK_PERSIST="${AUDIO_DISK_PERSIST:-false}"          # Move segments to disk (SD card wear!)
 readonly AUDIO_DISK_PATH="${AUDIO_DISK_PATH:-/var/lib/mediamtx-ffmpeg/recordings}"
 
 # Audio level monitoring (detect dead/silent microphones)
 readonly AUDIO_LEVEL_CHECK_ENABLED="${AUDIO_LEVEL_CHECK_ENABLED:-true}"  # Enable silence detection
-readonly AUDIO_LEVEL_SAMPLE_DURATION="${AUDIO_LEVEL_SAMPLE_DURATION:-3}" # Seconds to sample for level check
-readonly AUDIO_SILENCE_THRESHOLD_DB="${AUDIO_SILENCE_THRESHOLD_DB:--60}" # dB below which is "silence"
-readonly AUDIO_SILENCE_WARN_DURATION="${AUDIO_SILENCE_WARN_DURATION:-60}" # Seconds of silence before warning
+AUDIO_LEVEL_SAMPLE_DURATION=$(_uint_or "${AUDIO_LEVEL_SAMPLE_DURATION:-}" 3) # Seconds to sample for level check
+readonly AUDIO_LEVEL_SAMPLE_DURATION
+AUDIO_SILENCE_THRESHOLD_DB=$(_int_or "${AUDIO_SILENCE_THRESHOLD_DB:-}" -60) # dB below which is "silence"
+readonly AUDIO_SILENCE_THRESHOLD_DB
+AUDIO_SILENCE_WARN_DURATION=$(_uint_or "${AUDIO_SILENCE_WARN_DURATION:-}" 60) # Seconds of silence before warning
+readonly AUDIO_SILENCE_WARN_DURATION
 
 # MediaMTX API version compatibility
 readonly MEDIAMTX_API_VERSION="${MEDIAMTX_API_VERSION:-auto}"       # auto, v3, v2, v1
@@ -362,7 +422,8 @@ readonly MEDIAMTX_API_FALLBACK="${MEDIAMTX_API_FALLBACK:-true}"     # Try older 
 
 # USB device health checks
 readonly USB_ALSA_CHECK_ENABLED="${USB_ALSA_CHECK_ENABLED:-true}"   # Check ALSA availability before restart
-readonly USB_DISCONNECT_GRACE_PERIOD="${USB_DISCONNECT_GRACE_PERIOD:-10}" # Seconds to wait after disconnect
+USB_DISCONNECT_GRACE_PERIOD=$(_uint_or "${USB_DISCONNECT_GRACE_PERIOD:-}" 10) # Seconds to wait after disconnect
+readonly USB_DISCONNECT_GRACE_PERIOD
 
 # Version compatibility
 readonly MIN_COMPATIBLE_COMMON_VERSION="1.0.0"

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -3247,10 +3247,33 @@ wait_for_mediamtx_ready() {
 
 # Device configuration
 load_device_config() {
-    if [[ -f "${DEVICE_CONFIG_FILE}" ]]; then
-        # shellcheck source=/dev/null
-        source "${DEVICE_CONFIG_FILE}"
+    [[ -f "${DEVICE_CONFIG_FILE}" ]] || return 0
+
+    # A device config truncated by a power loss mid-write, corrupted by SD-card
+    # bit-rot, or fat-fingered by an operator would otherwise be `source`d
+    # directly: a syntax error then aborts the WHOLE run under errexit, so
+    # `start` fails and NO streams come up on the next unattended boot -- a
+    # total outage triggered by one bad line. Validate syntax first and, on
+    # failure, fall back to built-in defaults (degrade, don't die).
+    if ! bash -n "${DEVICE_CONFIG_FILE}" 2>/dev/null; then
+        log ERROR "Device config ${DEVICE_CONFIG_FILE} is corrupt (syntax error); ignoring it and using defaults"
+        return 0
     fi
+
+    # Even syntactically valid config is sourced defensively: a `set -e`/command
+    # inside it must not abort or hang the manager. Source in the current shell
+    # (values must persist) but neutralise errexit for the duration.
+    local _had_errexit=0
+    [[ $- == *e* ]] && _had_errexit=1
+    set +e
+    # shellcheck source=/dev/null
+    source "${DEVICE_CONFIG_FILE}"
+    local _src_rc=$?
+    [[ $_had_errexit -eq 1 ]] && set -e
+    if [[ $_src_rc -ne 0 ]]; then
+        log WARN "Device config ${DEVICE_CONFIG_FILE} raised errors while loading (rc=${_src_rc}); continuing with whatever loaded plus defaults"
+    fi
+    return 0
 }
 
 save_device_config() {

--- a/lyrebird-stream-manager.sh
+++ b/lyrebird-stream-manager.sh
@@ -2244,12 +2244,19 @@ check_audio_level() {
         if [[ -f "$silence_file" ]]; then
             silence_start=$(cat "$silence_file" 2>/dev/null || echo "0")
         else
-            silence_start=$(date +%s)
+            silence_start=$(_now_monotonic)
             echo "$silence_start" > "$silence_file" 2>/dev/null || true
         fi
 
         local now
-        now=$(date +%s)
+        now=$(_now_monotonic)
+        # A start value in the future means a stale wall-clock timestamp from a
+        # pre-monotonic run (or clock scale mismatch): restart tracking from now
+        # rather than silently never reaching the DEAD MIC threshold again.
+        if [[ ! "$silence_start" =~ ^[0-9]+$ ]] || ((silence_start > now)); then
+            silence_start=$now
+            echo "$silence_start" > "$silence_file" 2>/dev/null || true
+        fi
         local silence_duration=$((now - silence_start))
 
         if [[ $silence_duration -ge ${AUDIO_SILENCE_WARN_DURATION} ]]; then
@@ -2515,6 +2522,22 @@ is_cron_context() {
     return 1
 }
 
+# Monotonic seconds since boot. Wall-clock deltas (date +%s) are corrupted by
+# NTP steps, DST-adjacent RTC fixes and the first network clock set on an
+# RTC-less Pi; /proc/uptime never jumps. All boot-scoped timing state (backoff
+# runtimes, cron restart budgets, silence tracking -- kept under /run, which is
+# cleared at boot) uses this. Falls back to wall clock only when /proc/uptime
+# is unavailable.
+_now_monotonic() {
+    local up
+    if [[ -r /proc/uptime ]]; then
+        read -r up _ </proc/uptime
+        printf '%s' "${up%%.*}"
+    else
+        date +%s
+    fi
+}
+
 # --- Bounded cron resurrection (H8) -----------------------------------------
 # Count this stream's cron restarts within the last hour (read-only).
 _cron_restart_count() {
@@ -2522,7 +2545,7 @@ _cron_restart_count() {
     local state_file="${CRON_RESTART_STATE_DIR}/${stream_path}.restarts"
     [[ -f "$state_file" ]] || { printf '0'; return 0; }
     local now cutoff count=0 ts
-    now="$(date +%s)"
+    now="$(_now_monotonic)"
     cutoff=$((now - 3600))
     while read -r ts; do
         [[ "$ts" =~ ^[0-9]+$ ]] || continue
@@ -2537,7 +2560,7 @@ _record_cron_restart() {
     local state_file="${CRON_RESTART_STATE_DIR}/${stream_path}.restarts"
     mkdir -p "${CRON_RESTART_STATE_DIR}" 2>/dev/null || true
     local now cutoff kept="" ts
-    now="$(date +%s)"
+    now="$(_now_monotonic)"
     cutoff=$((now - 3600))
     if [[ -f "$state_file" ]]; then
         while read -r ts; do
@@ -3600,6 +3623,20 @@ log_critical() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [STREAM:${STREAM_PATH}] $1" >> "${LOG_FILE}" 2>/dev/null || true
 }
 
+# Monotonic seconds since boot for run-time/backoff math. Wall-clock deltas
+# break on NTP steps (an RTC-less Pi can jump years when it first gets
+# network): a healthy multi-hour run would measure negative and count as a
+# consecutive failure, eventually killing the wrapper on a healthy stream.
+now_s() {
+    local up
+    if [[ -r /proc/uptime ]]; then
+        read -r up _ < /proc/uptime
+        printf '%s' "${up%%.*}"
+    else
+        date +%s
+    fi
+}
+
 # Cleanup handler
 cleanup_wrapper() {
     local exit_code=$?
@@ -3812,7 +3849,7 @@ while true; do
     
     log_message "Starting FFmpeg (attempt #$((RESTART_COUNT + 1)))"
     
-    START_TIME=$(date +%s)
+    START_TIME=$(now_s)
     
     if ! run_ffmpeg; then
         log_message "Failed to start FFmpeg"
@@ -3840,7 +3877,7 @@ while true; do
     
     FFMPEG_PID=""
     
-    END_TIME=$(date +%s)
+    END_TIME=$(now_s)
     RUN_TIME=$((END_TIME - START_TIME))
     
     log_message "FFmpeg exited with code ${exit_code} after ${RUN_TIME} seconds"
@@ -4038,6 +4075,20 @@ log_critical() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [STREAM:${STREAM_PATH}] $1" >> "${LOG_FILE}" 2>/dev/null || true
 }
 
+# Monotonic seconds since boot for run-time/backoff math. Wall-clock deltas
+# break on NTP steps (an RTC-less Pi can jump years when it first gets
+# network): a healthy multi-hour run would measure negative and count as a
+# consecutive failure, eventually killing the wrapper on a healthy stream.
+now_s() {
+    local up
+    if [[ -r /proc/uptime ]]; then
+        read -r up _ < /proc/uptime
+        printf '%s' "${up%%.*}"
+    else
+        date +%s
+    fi
+}
+
 # Cleanup handler
 cleanup_wrapper() {
     local exit_code=$?
@@ -4228,7 +4279,7 @@ while true; do
     
     log_message "Starting FFmpeg (attempt #$((RESTART_COUNT + 1)))"
     
-    START_TIME=$(date +%s)
+    START_TIME=$(now_s)
     
     if ! run_ffmpeg; then
         log_message "Failed to start FFmpeg"
@@ -4256,7 +4307,7 @@ while true; do
     
     FFMPEG_PID=""
     
-    END_TIME=$(date +%s)
+    END_TIME=$(now_s)
     RUN_TIME=$((END_TIME - START_TIME))
     
     log_message "FFmpeg exited with code ${exit_code} after ${RUN_TIME} seconds"

--- a/lyrebird-updater.sh
+++ b/lyrebird-updater.sh
@@ -559,12 +559,12 @@ reinstall_service_with_customizations() {
         # Strategy: Insert custom env vars after the last Environment= line
         # This preserves the structure and ensures custom values override defaults
         local last_env_line_num
-        last_env_line_num=$(grep -n "^Environment=" "$service_file" | tail -n1 | cut -d: -f1)
+        last_env_line_num=$(grep -n "^Environment=" "$service_file" | tail -n1 | cut -d: -f1) || true
 
         if [[ -z "$last_env_line_num" ]]; then
             # No Environment= lines found - insert after WorkingDirectory
             local working_dir_line
-            working_dir_line=$(grep -n "^WorkingDirectory=" "$service_file" | tail -n1 | cut -d: -f1)
+            working_dir_line=$(grep -n "^WorkingDirectory=" "$service_file" | tail -n1 | cut -d: -f1) || true
 
             if [[ -n "$working_dir_line" ]]; then
                 # Insert after WorkingDirectory
@@ -2312,7 +2312,7 @@ list_available_releases() {
 
     local branch_counter=$((${#AVAILABLE_VERSIONS[@]} + 1))
     local git_branches
-    git_branches=$(git branch -r | grep -v HEAD | sed 's/origin\///' | sed 's/^[[:space:]]*//')
+    git_branches=$(git branch -r | grep -v HEAD | sed 's/origin\///' | sed 's/^[[:space:]]*//') || true
 
     if [[ -n "$git_branches" ]]; then
         while IFS= read -r branch; do

--- a/tests/test_config_crash_safety.bats
+++ b/tests/test_config_crash_safety.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Config-integrity / cold-start tests: a corrupt device config must degrade to
+# defaults, never abort `start`.
+#
+# load_device_config used to `source` the device config directly. A file
+# truncated by a power loss mid-write, corrupted by SD-card bit-rot, or
+# mis-edited by an operator then aborts the whole run under set -euo pipefail:
+# `start` fails and NO streams come up on the next unattended boot -- a total
+# outage from one bad line. The manager must ignore a corrupt config and use
+# built-in defaults, and must still honor a valid one.
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    CC_TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$CC_TMP" 2>/dev/null || true
+}
+
+@test "a truncated device config (unterminated array) does not abort start [cold-start]" {
+    # Simulates power loss mid-write: last line cut off.
+    cat > "$CC_TMP/audio-devices.conf" <<'EOF'
+DEVICE_YETI_SAMPLE_RATE=96000
+DEVICE_YETI_CHANNELS=(unterminated
+EOF
+    run env PROJECT_ROOT="$PROJECT_ROOT" MEDIAMTX_DEVICE_CONFIG="$CC_TMP/audio-devices.conf" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        log() { :; }
+        load_device_config
+        echo "START-CONTINUES"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"START-CONTINUES"* ]]
+}
+
+@test "a config with a stray command that fails does not abort start" {
+    cat > "$CC_TMP/audio-devices.conf" <<'EOF'
+DEVICE_YETI_SAMPLE_RATE=96000
+false
+DEVICE_YETI_CHANNELS=2
+EOF
+    run env PROJECT_ROOT="$PROJECT_ROOT" MEDIAMTX_DEVICE_CONFIG="$CC_TMP/audio-devices.conf" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        log() { :; }
+        load_device_config
+        echo "START-CONTINUES rate=${DEVICE_YETI_SAMPLE_RATE:-unset}"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"START-CONTINUES"* ]]
+}
+
+@test "errexit is restored after loading a config that touched set -e" {
+    printf 'DEVICE_X_SAMPLE_RATE=48000\n' > "$CC_TMP/audio-devices.conf"
+    run env PROJECT_ROOT="$PROJECT_ROOT" MEDIAMTX_DEVICE_CONFIG="$CC_TMP/audio-devices.conf" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        log() { :; }
+        load_device_config
+        case "$-" in *e*) echo "ERREXIT-ON" ;; *) echo "ERREXIT-OFF" ;; esac
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ERREXIT-ON"* ]]
+}
+
+@test "a valid device config is still honored (defaults not forced) [regression]" {
+    printf 'DEVICE_YETI_SAMPLE_RATE=192000\n' > "$CC_TMP/audio-devices.conf"
+    run env PROJECT_ROOT="$PROJECT_ROOT" MEDIAMTX_DEVICE_CONFIG="$CC_TMP/audio-devices.conf" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        log() { :; }
+        load_device_config
+        get_device_config "Yeti" "SAMPLE_RATE" "48000"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "192000" ]
+}

--- a/tests/test_deep_health_check.bats
+++ b/tests/test_deep_health_check.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+# Deep health probe (H9) E2E tests -- hardware-free.
+#
+# Before this feature, monitor_streams only verified that the wrapper's bash
+# PID existed. A wrapper stuck in endless backoff, or supervising a hung
+# FFmpeg whose path never publishes, reported "healthy" forever -- a field
+# node that looks alive while recording nothing. These tests drive the REAL
+# monitor_streams against a live fake wrapper process and a stub MediaMTX API
+# (PATH-shim curl) and prove monitor distinguishes healthy / degraded / dead.
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    DH_TMP="$(mktemp -d)"
+    mkdir -p "$DH_TMP/bin" "$DH_TMP/pids" "$DH_TMP/strikes" "$DH_TMP/cron"
+
+    # A fake "MediaMTX" process and a fake live wrapper process. It must be a
+    # bash process (read_pid_safe's PID-recycle guard rejects other comms) and
+    # all inherited FDs must be closed or bats waits on them and the file hangs.
+    # (the trailing ":" stops bash exec-optimizing itself away into comm=sleep)
+    bash -c 'sleep 300; :' >/dev/null 2>&1 3>&- &
+    FAKE_MTX_PID=$!
+    echo "$FAKE_MTX_PID" > "$DH_TMP/mediamtx.pid"
+}
+
+teardown() {
+    kill "$FAKE_MTX_PID" 2>/dev/null || true
+    [[ -n "${FAKE_WRAPPER_PID:-}" ]] && kill "$FAKE_WRAPPER_PID" 2>/dev/null || true
+    rm -rf "$DH_TMP" 2>/dev/null || true
+}
+
+# Stub API: paths/get/<name> answers with $1; everything else is a valid list.
+_write_api() {
+    local get_body="$1"
+    cat > "$DH_TMP/bin/curl" <<CURLEOF
+#!/bin/bash
+url="\${!#}"
+case "\$url" in
+    */paths/get/*) printf '%s' '${get_body}' ;;
+    *)             printf '%s' '{"itemCount":0,"items":[]}' ;;
+esac
+exit 0
+CURLEOF
+    chmod +x "$DH_TMP/bin/curl"
+}
+
+# An API that is down: curl always fails.
+_write_dead_api() {
+    printf '#!/bin/bash\nexit 7\n' > "$DH_TMP/bin/curl"
+    chmod +x "$DH_TMP/bin/curl"
+}
+
+# Start a live fake wrapper whose cmdline matches pgrep -f "<dir>/<stream>.sh"
+# and write its PID file, exactly as start_ffmpeg_stream would.
+_start_fake_wrapper() {
+    local stream="$1"
+    printf '#!/bin/bash\nsleep 300\n:\n' > "$DH_TMP/pids/${stream}.sh"
+    chmod +x "$DH_TMP/pids/${stream}.sh"
+    bash "$DH_TMP/pids/${stream}.sh" >/dev/null 2>&1 3>&- &
+    FAKE_WRAPPER_PID=$!
+    echo "$FAKE_WRAPPER_PID" > "$DH_TMP/pids/${stream}.pid"
+}
+
+# Run the REAL monitor_streams once with fakes layered over hardware access.
+_run_monitor() {
+    env PROJECT_ROOT="$PROJECT_ROOT" PATH="$DH_TMP/bin:$PATH" \
+        MEDIAMTX_PID_FILE="$DH_TMP/mediamtx.pid" \
+        MEDIAMTX_FFMPEG_DIR="$DH_TMP/pids" \
+        MEDIAMTX_LOG_FILE="$DH_TMP/manager.log" \
+        MEDIAMTX_API_VERSION=v3 \
+        DEEP_HEALTH_STATE_DIR="$DH_TMP/strikes" \
+        DEEP_HEALTH_MAX_STRIKES=3 \
+        CRON_RESTART_STATE_DIR="$DH_TMP/cron" \
+        RESTARTS_LOG="$DH_TMP/restarts.log" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+            detect_audio_devices() { printf "mic1:0\n"; }
+            check_alsa_device_available() { return 0; }
+            start_ffmpeg_stream() { echo "restart $1 $2 $3" >> "$RESTARTS_LOG"; return 0; }
+            start_ffmpeg_multiplex_stream() { return 0; }
+            monitor_streams
+        '
+}
+
+_stream_path_for_mic1() {
+    env PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        set +e
+        generate_stream_path "mic1" "0"
+    '
+}
+
+@test "monitor restarts a live wrapper whose path stays not-ready for 3 checks [H9]" {
+    local stream; stream="$(_stream_path_for_mic1)"
+    [ -n "$stream" ]
+    _start_fake_wrapper "$stream"
+    _write_api '{"name":"mic1","ready":false}'
+
+    # Strikes 1 and 2: no restart yet (protects mid-backoff streams from churn).
+    run _run_monitor
+    [ ! -f "$DH_TMP/restarts.log" ]
+    run _run_monitor
+    [ ! -f "$DH_TMP/restarts.log" ]
+
+    # Strike 3: the stream is confirmed stuck -> wrapper killed and restarted.
+    run _run_monitor
+    [ -f "$DH_TMP/restarts.log" ]
+    grep -q "restart mic1 0" "$DH_TMP/restarts.log"
+    # The stuck wrapper process must actually be gone.
+    ! kill -0 "$FAKE_WRAPPER_PID" 2>/dev/null
+}
+
+@test "monitor does NOT restart a wrapper whose path is ready [H9]" {
+    local stream; stream="$(_stream_path_for_mic1)"
+    _start_fake_wrapper "$stream"
+    _write_api '{"name":"mic1","ready":true}'
+
+    for _ in 1 2 3 4; do run _run_monitor; done
+    [ ! -f "$DH_TMP/restarts.log" ]
+    kill -0 "$FAKE_WRAPPER_PID" 2>/dev/null
+}
+
+@test "monitor accepts the NEW field shape (available:true) as healthy [H9]" {
+    local stream; stream="$(_stream_path_for_mic1)"
+    _start_fake_wrapper "$stream"
+    _write_api '{"name":"mic1","available":true}'
+
+    for _ in 1 2 3 4; do run _run_monitor; done
+    [ ! -f "$DH_TMP/restarts.log" ]
+    kill -0 "$FAKE_WRAPPER_PID" 2>/dev/null
+}
+
+@test "an unreachable API never strikes a stream (no churn on API blips) [H9]" {
+    local stream; stream="$(_stream_path_for_mic1)"
+    _start_fake_wrapper "$stream"
+    _write_dead_api
+
+    for _ in 1 2 3 4 5; do run _run_monitor; done
+    [ ! -f "$DH_TMP/restarts.log" ]
+    kill -0 "$FAKE_WRAPPER_PID" 2>/dev/null
+}
+
+@test "a ready probe resets the strike counter (flapping does not accumulate) [H9]" {
+    local stream; stream="$(_stream_path_for_mic1)"
+    _start_fake_wrapper "$stream"
+
+    # Two strikes...
+    _write_api '{"name":"mic1","ready":false}'
+    run _run_monitor
+    run _run_monitor
+    # ...then a healthy probe clears them...
+    _write_api '{"name":"mic1","ready":true}'
+    run _run_monitor
+    # ...so two more strikes still do not reach the threshold of 3.
+    _write_api '{"name":"mic1","ready":false}'
+    run _run_monitor
+    run _run_monitor
+    [ ! -f "$DH_TMP/restarts.log" ]
+    kill -0 "$FAKE_WRAPPER_PID" 2>/dev/null
+}
+
+@test "deep health check can be disabled via DEEP_HEALTH_CHECK_ENABLED=false" {
+    local stream; stream="$(_stream_path_for_mic1)"
+    _start_fake_wrapper "$stream"
+    _write_api '{"name":"mic1","ready":false}'
+
+    for _ in 1 2 3 4; do
+        run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$DH_TMP/bin:$PATH" \
+            MEDIAMTX_PID_FILE="$DH_TMP/mediamtx.pid" \
+            MEDIAMTX_FFMPEG_DIR="$DH_TMP/pids" \
+            MEDIAMTX_LOG_FILE="$DH_TMP/manager.log" \
+            MEDIAMTX_API_VERSION=v3 \
+            DEEP_HEALTH_CHECK_ENABLED=false \
+            DEEP_HEALTH_STATE_DIR="$DH_TMP/strikes" \
+            CRON_RESTART_STATE_DIR="$DH_TMP/cron" \
+            RESTARTS_LOG="$DH_TMP/restarts.log" \
+            bash -c '
+                set -euo pipefail
+                source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+                detect_audio_devices() { printf "mic1:0\n"; }
+                check_alsa_device_available() { return 0; }
+                start_ffmpeg_stream() { echo "restart" >> "$RESTARTS_LOG"; return 0; }
+                start_ffmpeg_multiplex_stream() { return 0; }
+                monitor_streams
+            '
+    done
+    [ ! -f "$DH_TMP/restarts.log" ]
+}

--- a/tests/test_e2e_stream_wrapper.bats
+++ b/tests/test_e2e_stream_wrapper.bats
@@ -17,8 +17,10 @@ teardown() {
 }
 
 # Extract the individual wrapper's restart loop (the 2nd "# Main restart loop"),
-# stopping before the heredoc terminator.
+# stopping before the heredoc terminator, plus the real now_s helper it calls.
 _extract_restart_loop() {
+    awk '/^now_s\(\) \{$/ { c++; if (c == 1) p = 1 } p { print } p && /^\}$/ { exit }' \
+        "$PROJECT_ROOT/lyrebird-stream-manager.sh"
     awk '
         /^# Main restart loop$/ { c++ }
         c == 2 { print }

--- a/tests/test_lyrebird_metrics.bats
+++ b/tests/test_lyrebird_metrics.bats
@@ -322,3 +322,17 @@ CURLEOF
     [ "$(printf '%s\n' "$output" | grep -c .)" -eq 1 ]     # exactly one line
     [[ "$output" == *'stream="AKG \"C414\""'* ]]
 }
+
+@test "scrape output carries an in-band staleness timestamp [stale-.prom detection]" {
+    # A .prom left behind by a dead exporter must be detectable: every scrape
+    # embeds the Unix time it was generated so Prometheus can alert on age.
+    run env PROJECT_ROOT="$PROJECT_ROOT" \
+        FFMPEG_PID_DIR="$(mktemp -d)" PID_FILE="$(mktemp)" HEARTBEAT_FILE="$(mktemp)" \
+        bash -c 'set -euo pipefail; source "$PROJECT_ROOT/lyrebird-metrics.sh"; generate_all_metrics'
+    [ "$status" -eq 0 ]
+    local ts now
+    ts=$(printf '%s\n' "$output" | awk '/^lyrebird_scrape_timestamp_seconds /{print $2}')
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    now=$(date +%s)
+    (( now - ts < 120 ))     # fresh, not a stale leftover value
+}

--- a/tests/test_mediamtx_json_compat.bats
+++ b/tests/test_mediamtx_json_compat.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+# MediaMTX control-API JSON compatibility + abort-safety tests.
+#
+# Two failure classes are locked down here:
+#  1. errexit/pipefail abort: count=$(echo "$json" | grep -o PAT | wc -l) makes
+#     the WHOLE script die when grep matches nothing (pipefail -> assignment
+#     fails -> errexit), so "0 ready paths" killed the manager mid-run.
+#  2. Deprecated field shapes: "ready" is deprecated in favour of "available";
+#     a future MediaMTX that drops "ready" must not make every stream look dead.
+#
+# All tests drive the REAL functions from lyrebird-stream-manager.sh /
+# lyrebird-metrics.sh against a stub MediaMTX API (PATH-shim fake curl).
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    JC_TMP="$(mktemp -d)"
+    mkdir -p "$JC_TMP/bin"
+}
+
+teardown() {
+    rm -rf "$JC_TMP" 2>/dev/null || true
+}
+
+# Write a fake curl that answers /v3/paths/list and /v3/paths/get/* with the
+# JSON bodies given as $2 / $3. mediamtx_api_call appends "\n%{http_code}".
+_write_stub_curl() {
+    local list_json="$1" get_json="$2"
+    cat > "$JC_TMP/bin/curl" <<CURLEOF
+#!/bin/bash
+url="\${!#}"
+for a in "\$@"; do
+    case "\$a" in *%{http_code}*) with_code=1 ;; esac
+done
+body='{}'
+case "\$url" in
+    */paths/list*) body='${list_json}' ;;
+    */paths/get/*) body='${get_json}' ;;
+    */v3/info*)    body='{"version":"1.19.2","upTime":123456}' ;;
+esac
+if [[ "\${with_code:-0}" == "1" ]]; then
+    printf '%s\n200' "\$body"
+else
+    printf '%s' "\$body"
+fi
+exit 0
+CURLEOF
+    chmod +x "$JC_TMP/bin/curl"
+}
+
+# Run a snippet with the real stream-manager sourced and the stub API on PATH.
+_sm() {
+    env PROJECT_ROOT="$PROJECT_ROOT" PATH="$JC_TMP/bin:$PATH" \
+        MEDIAMTX_API_VERSION=v3 \
+        bash -c "set -euo pipefail; source \"\$PROJECT_ROOT/lyrebird-stream-manager.sh\" >/dev/null 2>&1; $1"
+}
+
+# --- 1. abort-safety (errexit/pipefail) -------------------------------------
+
+@test "count_ready_paths with ZERO ready paths returns 0 instead of killing the script [N1]" {
+    _write_stub_curl '{"itemCount":0,"items":[]}' '{}'
+    run _sm 'mediamtx_count_ready_paths; echo "SURVIVED"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SURVIVED"* ]]
+    [[ "$output" == *"0"* ]]
+}
+
+@test "count_rtsp_sessions with zero sessions survives under set -euo pipefail [N1]" {
+    _write_stub_curl '{"itemCount":0,"items":[]}' '{}'
+    run _sm 'mediamtx_count_rtsp_sessions; echo "SURVIVED"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SURVIVED"* ]]
+}
+
+@test "count_all_connections with an idle server survives and prints 0 [N1]" {
+    _write_stub_curl '{"itemCount":0,"items":[]}' '{}'
+    run _sm 'mediamtx_count_all_connections; echo "SURVIVED"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SURVIVED"* ]]
+}
+
+@test "get_status_summary with zero ready paths completes instead of aborting mid-print [N1]" {
+    _write_stub_curl '{"itemCount":1,"items":[{"name":"mic1","ready":false}]}' '{}'
+    run _sm 'mediamtx_get_status_summary'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"0/1 ready"* ]]
+}
+
+# --- 2. deprecated vs current field shapes ----------------------------------
+
+@test "path_is_ready accepts the OLD shape (ready:true only)" {
+    _write_stub_curl '{}' '{"name":"mic1","ready":true}'
+    run _sm 'mediamtx_path_is_ready mic1 && echo YES'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"YES"* ]]
+}
+
+@test "path_is_ready accepts the NEW shape (available:true, no ready field)" {
+    _write_stub_curl '{}' '{"name":"mic1","available":true,"tracks2":[{"type":"audio"}]}'
+    run _sm 'mediamtx_path_is_ready mic1 && echo YES'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"YES"* ]]
+}
+
+@test "path_is_ready prefers the new field when both are present and disagree" {
+    # Transitional server: available=false must win over a stale ready=true.
+    _write_stub_curl '{}' '{"name":"mic1","ready":true,"available":false}'
+    run _sm 'mediamtx_path_is_ready mic1 || echo NOTREADY'
+    [[ "$output" == *"NOTREADY"* ]]
+}
+
+@test "path_is_ready is not fooled by ready:false" {
+    _write_stub_curl '{}' '{"name":"mic1","ready":false}'
+    run _sm 'mediamtx_path_is_ready mic1 || echo NOTREADY'
+    [[ "$output" == *"NOTREADY"* ]]
+}
+
+@test "count_ready_paths counts NEW-shape (available) paths" {
+    _write_stub_curl '{"itemCount":2,"items":[{"name":"a","available":true},{"name":"b","available":false}]}' '{}'
+    run _sm 'mediamtx_count_ready_paths'
+    [ "$status" -eq 0 ]
+    [ "${lines[-1]}" = "1" ]
+}
+
+@test "count_ready_paths does not double-count when BOTH fields are present" {
+    _write_stub_curl '{"itemCount":2,"items":[{"name":"a","ready":true,"available":true},{"name":"b","ready":true,"available":true}]}' '{}'
+    run _sm 'mediamtx_count_ready_paths'
+    [ "$status" -eq 0 ]
+    [ "${lines[-1]}" = "2" ]
+}
+
+@test "validate_stream succeeds against a NEW-shape paths/get response" {
+    _write_stub_curl '{}' '{"name":"mic1","available":true}'
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$JC_TMP/bin:$PATH" \
+        MEDIAMTX_API_VERSION=v3 STREAM_VALIDATION_DELAY=0 STREAM_VALIDATION_ATTEMPTS=1 \
+        bash -c 'set -euo pipefail; source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1; validate_stream mic1 && echo VALID'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"VALID"* ]]
+}
+
+@test "metrics api_paths_ready counts NEW-shape paths" {
+    cat > "$JC_TMP/bin/curl" <<'CURLEOF'
+#!/bin/bash
+url="${!#}"
+case "$url" in
+    */v3/info)       echo '{"version":"1.19.2","upTime":123456}' ;;
+    */v3/paths/list) echo '{"itemCount":2,"items":[{"name":"a","available":true},{"name":"b","available":true}]}' ;;
+    *)               echo '{"itemCount":0,"items":[]}' ;;
+esac
+exit 0
+CURLEOF
+    chmod +x "$JC_TMP/bin/curl"
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$JC_TMP/bin:$PATH" \
+        FFMPEG_PID_DIR="$(mktemp -d)" PID_FILE="$(mktemp)" HEARTBEAT_FILE="$(mktemp)" \
+        bash -c 'set -euo pipefail; source "$PROJECT_ROOT/lyrebird-metrics.sh"; generate_all_metrics'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"lyrebird_api_paths_ready 2"* ]]
+}

--- a/tests/test_monotonic_timing.bats
+++ b/tests/test_monotonic_timing.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# Monotonic-timing regression tests (the deferred "non-monotonic timing" item).
+#
+# A field Pi without an RTC boots with a bogus clock and steps it -- sometimes
+# by years -- when NTP first syncs. Wall-clock deltas (date +%s) then corrupt:
+#  - the wrapper's RUN_TIME (a healthy multi-hour run measures negative and is
+#    counted as a consecutive FAILURE -> wrapper eventually gives up), and
+#  - the cron restart budget (a forward step ages every recorded restart out
+#    of the window -> the anti-storm budget evaporates).
+# The fix reads /proc/uptime (monotonic). These tests simulate clock jumps
+# with a PATH-shim `date` and prove the timing survives them.
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    MT_TMP="$(mktemp -d)"
+    mkdir -p "$MT_TMP/bin"
+}
+
+teardown() {
+    rm -rf "$MT_TMP" 2>/dev/null || true
+}
+
+# A fake `date` whose +%s output JUMPS BACKWARD 5000s on every call; all other
+# formats pass through to the real date.
+_write_jumping_date() {
+    date +%s > "$MT_TMP/date.state"
+    cat > "$MT_TMP/bin/date" <<EOF
+#!/bin/bash
+if [[ "\${1:-}" == "+%s" ]]; then
+    n=\$(cat "$MT_TMP/date.state")
+    echo "\$n"
+    echo \$((n - 5000)) > "$MT_TMP/date.state"
+else
+    exec /bin/date "\$@"
+fi
+EOF
+    chmod +x "$MT_TMP/bin/date"
+}
+
+# Extract the real now_s helper and the real (2nd, individual-stream) restart
+# loop from the generated-wrapper heredocs.
+_extract_now_s() {
+    awk '/^now_s\(\) \{$/ { c++; if (c == 1) p = 1 } p { print } p && /^\}$/ { exit }' \
+        "$PROJECT_ROOT/lyrebird-stream-manager.sh"
+}
+
+_extract_restart_loop() {
+    awk '
+        /^# Main restart loop$/ { c++ }
+        c == 2 { print }
+        /^log_message "Wrapper exiting/ && c == 2 { exit }
+    ' "$PROJECT_ROOT/lyrebird-stream-manager.sh"
+}
+
+@test "wrapper does not count healthy runs as failures across BACKWARD clock jumps [E2E]" {
+    # ffmpeg fake: runs 2s (> WRAPPER_SUCCESS_DURATION=1) then exits cleanly --
+    # every run is healthy. The jumping `date` makes each wall-clock RUN_TIME
+    # negative; pre-fix that increments CONSECUTIVE_FAILURES until the wrapper
+    # gives up after exactly MAX_CONSECUTIVE_FAILURES=2 launches.
+    cat > "$MT_TMP/bin/ffmpeg" <<EOF
+#!/bin/bash
+echo "call" >> "$MT_TMP/calls.log"
+sleep 2
+exit 0
+EOF
+    chmod +x "$MT_TMP/bin/ffmpeg"
+    : > "$MT_TMP/calls.log"
+    _write_jumping_date
+
+    local wrapper="$MT_TMP/wrapper.sh"
+    {
+        echo '#!/bin/bash'
+        echo 'set -euo pipefail'
+        echo "export PATH=\"$MT_TMP/bin:\$PATH\""
+        cat <<'CFG'
+STREAM_PATH="testmic"; CARD_NUM=0; FFMPEG_PID=""
+CLEANUP_MARKER="/nonexistent/cleanup.marker"
+RESTART_COUNT=0; CONSECUTIVE_FAILURES=0
+MAX_CONSECUTIVE_FAILURES=2; MAX_WRAPPER_RESTARTS=100
+WRAPPER_SUCCESS_DURATION=1
+INITIAL_RESTART_DELAY=1; MAX_RESTART_DELAY=1; RESTART_DELAY=1
+log_message() { :; }
+log_critical() { :; }
+check_parent_alive() { return 0; }
+check_device_exists() { return 0; }
+run_ffmpeg() { ffmpeg >/dev/null 2>&1 & FFMPEG_PID=$!; return 0; }
+CFG
+        _extract_now_s
+        _extract_restart_loop
+    } > "$wrapper"
+    bash -n "$wrapper"
+
+    # Pre-fix: exactly 2 launches then the wrapper quits ("too many consecutive
+    # failures") even though every run was healthy. Post-fix: it keeps going.
+    timeout 12s bash "$wrapper" || true
+    local calls
+    calls=$(grep -c 'call' "$MT_TMP/calls.log" 2>/dev/null || echo 0)
+    [ "$calls" -ge 3 ]
+}
+
+@test "cron restart budget survives a FORWARD clock jump (anti-storm guarantee) [H8]" {
+    # Record 3 restarts, then step the wall clock +2h. Pre-fix the budget
+    # window is computed from date +%s, so every recorded restart ages out and
+    # the count collapses to 0 -- the restart-storm brake evaporates.
+    cat > "$MT_TMP/bin/date" <<EOF
+#!/bin/bash
+if [[ "\${1:-}" == "+%s" ]]; then
+    echo \$(( \$(/bin/date +%s) + 7200 ))
+else
+    exec /bin/date "\$@"
+fi
+EOF
+    chmod +x "$MT_TMP/bin/date"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" MT_TMP="$MT_TMP" \
+        CRON_RESTART_STATE_DIR="$MT_TMP/cron" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        log() { :; }
+        # Record with the REAL clock...
+        _record_cron_restart mic1
+        _record_cron_restart mic1
+        _record_cron_restart mic1
+        # ...then count with the clock stepped +2h.
+        export PATH="$MT_TMP/bin:$PATH"
+        _cron_restart_count mic1
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "3" ]
+}
+
+@test "cron restart budget is not corrupted by a BACKWARD clock jump" {
+    cat > "$MT_TMP/bin/date" <<EOF
+#!/bin/bash
+if [[ "\${1:-}" == "+%s" ]]; then
+    echo \$(( \$(/bin/date +%s) - 7200 ))
+else
+    exec /bin/date "\$@"
+fi
+EOF
+    chmod +x "$MT_TMP/bin/date"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" MT_TMP="$MT_TMP" \
+        CRON_RESTART_STATE_DIR="$MT_TMP/cron" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        log() { :; }
+        _record_cron_restart mic1
+        _record_cron_restart mic1
+        export PATH="$MT_TMP/bin:$PATH"
+        _cron_restart_count mic1
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "2" ]
+}
+
+@test "silence tracking does not fire a false DEAD MIC after a forward clock jump" {
+    # First check records silence-start; then the wall clock steps +2h; the
+    # second check must NOT conclude the mic has been dead for 2 hours.
+    mkdir -p "$MT_TMP/ffbin"
+    cat > "$MT_TMP/ffbin/ffmpeg" <<'EOF'
+#!/bin/bash
+echo "[Parsed_volumedetect_0 @ 0x0] max_volume: -91.0 dB" >&2
+exit 0
+EOF
+    chmod +x "$MT_TMP/ffbin/ffmpeg"
+    cp "$MT_TMP/ffbin/ffmpeg" "$MT_TMP/bin/ffmpeg"
+    cat > "$MT_TMP/bin/date" <<EOF
+#!/bin/bash
+if [[ "\${1:-}" == "+%s" ]]; then
+    echo \$(( \$(/bin/date +%s) + 7200 ))
+else
+    exec /bin/date "\$@"
+fi
+EOF
+    chmod +x "$MT_TMP/bin/date"
+
+    local stream="mtjumptest$$"
+    rm -f "/run/mediamtx-silence-${stream}" 2>/dev/null || true
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" MT_TMP="$MT_TMP" STREAM="$stream" \
+        AUDIO_LEVEL_CHECK_ENABLED=true AUDIO_SILENCE_WARN_DURATION=6000 \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+            msgs="$MT_TMP/log.txt"
+            log() { echo "$*" >> "$msgs"; }
+            export PATH="$MT_TMP/ffbin:$PATH"
+            check_audio_level 0 "$STREAM" || true   # records silence start
+            export PATH="$MT_TMP/bin:$PATH"         # NOW the clock steps +2h
+            check_audio_level 0 "$STREAM" || true
+            cat "$msgs"
+        '
+    rm -f "/run/mediamtx-silence-${stream}" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Silence detected"* ]]
+    [[ "$output" != *"DEAD MIC"* ]]
+}

--- a/tests/test_numeric_env_hardening.bats
+++ b/tests/test_numeric_env_hardening.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# Config-integrity tests: a non-numeric env override must never abort a run.
+#
+# Every numeric knob is env-overridable and consumed in bash arithmetic. A
+# value like CRON_RESTART_MAX_PER_HOUR=unlimited reaches (( count < ... )),
+# bash resolves "unlimited" as a variable name, and under set -u/-e the whole
+# script dies with "unbound variable" -- silently killing every cron monitor
+# pass on a node whose operator merely wrote an intuitive config value. The
+# stream manager now coerces all numeric env knobs to sane defaults at load.
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    NE_TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$NE_TMP" 2>/dev/null || true
+}
+
+@test "CRON_RESTART_MAX_PER_HOUR=unlimited does not abort the restart-budget decision" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" \
+        CRON_RESTART_MAX_PER_HOUR="unlimited" \
+        CRON_RESTART_STATE_DIR="$NE_TMP/cron" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+            log() { :; }
+            is_cron_context() { return 0; }   # force the cron budget path
+            rc=0
+            should_restart_stream mic1 || rc=$?
+            echo "DECIDED rc=$rc budget=$CRON_RESTART_MAX_PER_HOUR"
+        '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DECIDED rc=0"* ]]      # falls back to the default (6), allows restart
+    [[ "$output" == *"budget=6"* ]]
+}
+
+@test "DEEP_HEALTH_MAX_STRIKES=lots does not abort the deep health probe" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" \
+        DEEP_HEALTH_MAX_STRIKES="lots" \
+        DEEP_HEALTH_STATE_DIR="$NE_TMP/strikes" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+            log() { :; }
+            rc=0
+            deep_health_note mic1 notready || rc=$?
+            echo "NOTED rc=$rc strikes=$DEEP_HEALTH_MAX_STRIKES"
+        '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NOTED"* ]]
+    [[ "$output" == *"strikes=3"* ]]         # coerced to the default
+}
+
+@test "MAX_RESTART_DELAY=5min falls back to the numeric default (wrapper backoff stays sane)" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" MAX_RESTART_DELAY="5min" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        echo "delay=$MAX_RESTART_DELAY"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "delay=300" ]
+}
+
+@test "AUDIO_SILENCE_THRESHOLD_DB keeps a valid negative override and rejects garbage" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" AUDIO_SILENCE_THRESHOLD_DB="-45" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        echo "db=$AUDIO_SILENCE_THRESHOLD_DB"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "db=-45" ]
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" AUDIO_SILENCE_THRESHOLD_DB="quiet" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        echo "db=$AUDIO_SILENCE_THRESHOLD_DB"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "db=-60" ]
+}
+
+@test "a valid numeric override is preserved, not clobbered by coercion" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" CRON_RESTART_MAX_PER_HOUR="12" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        echo "budget=$CRON_RESTART_MAX_PER_HOUR"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget=12" ]
+}

--- a/tests/test_pipefail_aborts.bats
+++ b/tests/test_pipefail_aborts.bats
@@ -173,8 +173,21 @@ echo "DEVPATH=/devices/platform/soc/fe00b840.mailbox/sound"
 exit 0
 EOF
     chmod +x "$PA_TMP/bin/udevadm"
-    mkdir -p /dev/bus/usb/990
-    : > /dev/bus/usb/990/991
+
+    # The function only consults udevadm when /dev/bus/usb/<bus>/<dev> exists.
+    # Creating that node needs root: do it directly when we are root, via
+    # non-interactive sudo on CI runners, and skip (with the reason) elsewhere
+    # rather than fail on an environment limitation.
+    if mkdir -p /dev/bus/usb/990 2>/dev/null; then
+        : > /dev/bus/usb/990/991
+        PA_DEV_SUDO=""
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        sudo -n mkdir -p /dev/bus/usb/990
+        sudo -n touch /dev/bus/usb/990/991
+        PA_DEV_SUDO="sudo -n"
+    else
+        skip "cannot create /dev/bus/usb test node (needs root or passwordless sudo)"
+    fi
 
     run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" bash -c '
         set -euo pipefail
@@ -183,7 +196,7 @@ EOF
         get_usb_physical_port 990 991 || rc=$?
         echo "COMPLETED rc=$rc"
     '
-    rm -rf /dev/bus/usb/990
+    ${PA_DEV_SUDO} rm -rf /dev/bus/usb/990
     [ "$status" -eq 0 ]
     [[ "$output" == *"COMPLETED"* ]]
 }

--- a/tests/test_pipefail_aborts.bats
+++ b/tests/test_pipefail_aborts.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+# Regression tests for the errexit/pipefail silent-abort class (N2 sweep).
+#
+# Pattern: var=$(cmd | grep PAT | tail/cut/awk/head ...) under set -euo pipefail.
+# When grep matches nothing the PIPELINE fails (pipefail), the assignment fails,
+# and errexit kills the whole script mid-run -- even though the very next lines
+# handle the empty-variable case. Every test here drives a REAL function into
+# its documented fallback path; before the guards, each one aborted instead.
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    PA_TMP="$(mktemp -d)"
+    mkdir -p "$PA_TMP/bin"
+}
+
+teardown() {
+    rm -rf "$PA_TMP" 2>/dev/null || true
+}
+
+@test "diagnostics: NTP offset probe survives an UNSYNCED ntpd (the normal pre-sync field state)" {
+    # ntpq -p output with peers but no '*'/'o' selected peer => grep matches 0 lines.
+    cat > "$PA_TMP/bin/ntpq" <<'EOF'
+#!/bin/bash
+echo "     remote           refid      st t when poll reach   delay   offset  jitter"
+echo "=============================================================================="
+echo " 0.debian.pool.n .POOL.          16 p    -   64    0    0.000   +0.000   0.000"
+exit 0
+EOF
+    chmod +x "$PA_TMP/bin/ntpq"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-diagnostics.sh" >/dev/null 2>&1
+        get_ntp_offset_ms
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unknown"* ]]
+}
+
+@test "diagnostics: NTP offset probe survives chronyd not running" {
+    rm -f "$PA_TMP/bin/ntpq"
+    cat > "$PA_TMP/bin/chronyc" <<'EOF'
+#!/bin/bash
+echo "506 Cannot talk to daemon" >&2
+exit 1
+EOF
+    chmod +x "$PA_TMP/bin/chronyc"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-diagnostics.sh" >/dev/null 2>&1
+        command -v ntpq >/dev/null 2>&1 && exit 99   # test needs chronyc branch
+        get_ntp_offset_ms
+    '
+    if [ "$status" -eq 99 ]; then
+        skip "real ntpq present on this host; chronyc branch unreachable"
+    fi
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unknown"* ]]
+}
+
+@test "diagnostics: get_script_version on a script with NO version marker returns 'unknown'" {
+    printf '#!/bin/bash\necho hi\n' > "$PA_TMP/noversion.sh"
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-diagnostics.sh" >/dev/null 2>&1
+        get_script_version "'"$PA_TMP"'/noversion.sh"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "stream-manager: check_audio_level survives ffmpeg exiting 0 with NO volumedetect output" {
+    # An ffmpeg that succeeds but prints nothing parseable (e.g. muted loglevel,
+    # driver quirk). Must return 2 (check failed), never abort the monitor run.
+    printf '#!/bin/bash\nexit 0\n' > "$PA_TMP/bin/ffmpeg"
+    chmod +x "$PA_TMP/bin/ffmpeg"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" \
+        AUDIO_LEVEL_CHECK_ENABLED=true bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        log() { :; }
+        rc=0
+        check_audio_level 0 pipefailtest || rc=$?
+        echo "rc=$rc"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"rc=2"* ]]
+}
+
+@test "stream-manager: get_status_summary survives an /v3/info body without a version field" {
+    cat > "$PA_TMP/bin/curl" <<'EOF'
+#!/bin/bash
+url="${!#}"
+with_code=0
+for a in "$@"; do case "$a" in *%{http_code}*) with_code=1 ;; esac; done
+case "$url" in
+    */info*) body='{"upTime":1}' ;;
+    *)       body='{"itemCount":0,"items":[]}' ;;
+esac
+if [[ $with_code -eq 1 ]]; then printf '%s\n200' "$body"; else printf '%s' "$body"; fi
+exit 0
+EOF
+    chmod +x "$PA_TMP/bin/curl"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" MEDIAMTX_API_VERSION=v3 bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-stream-manager.sh" >/dev/null 2>&1
+        mediamtx_get_status_summary
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unknown"* ]]
+}
+
+@test "metrics: collect_mediamtx_metrics survives MediaMTX dying between the two pgrep calls" {
+    # Stateful pgrep: first call (the running check) succeeds, second call (the
+    # PID fetch) finds nothing -- the process died in between. The scrape must
+    # still complete (a mid-scrape abort leaves a stale .prom: dead recorder
+    # looks alive).
+    : > "$PA_TMP/pgrep.calls"
+    cat > "$PA_TMP/bin/pgrep" <<EOF
+#!/bin/bash
+echo x >> "$PA_TMP/pgrep.calls"
+n=\$(wc -l < "$PA_TMP/pgrep.calls")
+if [[ \$n -le 1 ]]; then echo 12345; exit 0; else exit 1; fi
+EOF
+    chmod +x "$PA_TMP/bin/pgrep"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-metrics.sh"
+        collect_mediamtx_metrics
+        echo "SCRAPE-COMPLETE"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SCRAPE-COMPLETE"* ]]
+}
+
+@test "orchestrator: stream count survives ffmpeg dying between the two pgrep calls (BusyBox fallback path)" {
+    # pgrep whose --help does NOT advertise -c (BusyBox-style) so the fallback
+    # `pgrep -x ffmpeg | head | wc -l` path runs; the gate call sees ffmpeg,
+    # the count call does not.
+    : > "$PA_TMP/pgrep.calls"
+    cat > "$PA_TMP/bin/pgrep" <<EOF
+#!/bin/bash
+if [[ "\$*" == *--help* ]]; then echo "usage: pgrep [-flnovx] PATTERN"; exit 0; fi
+if [[ "\$*" == *mediamtx* ]]; then exit 1; fi
+echo x >> "$PA_TMP/pgrep.calls"
+n=\$(wc -l < "$PA_TMP/pgrep.calls")
+if [[ \$n -le 1 ]]; then echo 12345; exit 0; else exit 1; fi
+EOF
+    chmod +x "$PA_TMP/bin/pgrep"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/lyrebird-orchestrator.sh" >/dev/null 2>&1
+        log() { :; }
+        refresh_system_state
+        echo "STATE-REFRESHED streams=$ACTIVE_STREAMS"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STATE-REFRESHED streams=0"* ]]
+}
+
+@test "usb-mapper: get_usb_physical_port survives a DEVPATH with no usb port pattern" {
+    # udevadm answers with a platform-bus DEVPATH (no N-N.N segment): the
+    # extraction grep matches nothing and must fall through, not abort.
+    cat > "$PA_TMP/bin/udevadm" <<'EOF'
+#!/bin/bash
+echo "DEVPATH=/devices/platform/soc/fe00b840.mailbox/sound"
+exit 0
+EOF
+    chmod +x "$PA_TMP/bin/udevadm"
+    mkdir -p /dev/bus/usb/990
+    : > /dev/bus/usb/990/991
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PATH="$PA_TMP/bin:$PATH" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/usb-audio-mapper.sh" >/dev/null 2>&1
+        rc=0
+        get_usb_physical_port 990 991 || rc=$?
+        echo "COMPLETED rc=$rc"
+    '
+    rm -rf /dev/bus/usb/990
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"COMPLETED"* ]]
+}
+
+@test "installer: verify_checksum reports a MISSING checksum entry instead of aborting" {
+    echo "binary-data" > "$PA_TMP/mediamtx.tar.gz"
+    echo "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  other_file.tar.gz" \
+        > "$PA_TMP/checksums.sha256"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PA_TMP="$PA_TMP" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/install_mediamtx.sh" >/dev/null 2>&1
+        rc=0
+        verify_checksum "$PA_TMP/mediamtx.tar.gz" "$PA_TMP/checksums.sha256" "mediamtx.tar.gz" || rc=$?
+        echo "HANDLED rc=$rc"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"HANDLED rc=1"* ]]
+}
+
+@test "installer: show_status prints 'unknown' for a version-less mediamtx binary" {
+    mkdir -p "$PA_TMP/prefix/bin"
+    printf '#!/bin/bash\necho "development build"\nexit 0\n' > "$PA_TMP/prefix/bin/mediamtx"
+    chmod +x "$PA_TMP/prefix/bin/mediamtx"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" MEDIAMTX_PREFIX="$PA_TMP/prefix" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/install_mediamtx.sh" >/dev/null 2>&1
+        show_status || true
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Version: unknown"* ]]
+}
+
+@test "updater: service-env merge survives a service file with NO Environment= lines" {
+    cat > "$PA_TMP/test.service" <<'EOF'
+[Unit]
+Description=Test service
+
+[Service]
+WorkingDirectory=/opt/test
+ExecStart=/bin/true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    printf '#!/bin/bash\nexit 0\n' > "$PA_TMP/fake-manager.sh"
+    chmod +x "$PA_TMP/fake-manager.sh"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" PA_TMP="$PA_TMP" bash -c '
+        set -o errexit -o pipefail -o nounset
+        source "$PROJECT_ROOT/lyrebird-updater.sh" >/dev/null 2>&1
+        SERVICE_STATE[has_customizations]="true"
+        SERVICE_STATE[service_file]="$PA_TMP/test.service"
+        SERVICE_CUSTOM_ENV=("Environment=LYREBIRD_CUSTOM=yes")
+        reinstall_service_with_customizations "$PA_TMP/fake-manager.sh"
+        echo "MERGE-COMPLETE"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"MERGE-COMPLETE"* ]]
+    grep -q 'Environment=LYREBIRD_CUSTOM=yes' "$PA_TMP/test.service"
+}

--- a/tests/test_storage_clock_sanity.bats
+++ b/tests/test_storage_clock_sanity.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Retention vs broken-clock tests (long-horizon / time domain).
+#
+# Field scenario: an RTC-less Pi records for hours with its clock still in
+# 1970, then NTP steps the clock to the real date. The next retention run's
+# `find -mtime +30` sees those minutes-old recordings as ~56 years old and
+# deletes fresh data -- a silent mass-loss incident. Age-based cleanup must
+# treat any mtime before CLOCK_SANE_EPOCH as "real age unknown: keep", and an
+# unsynced current clock as "ages are meaningless: skip". Emergency size-based
+# cleanup is deliberately exempt (a full disk must still be freed).
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    CS_TMP="$(mktemp -d)"
+    mkdir -p "$CS_TMP/rec" "$CS_TMP/bin"
+}
+
+teardown() {
+    rm -rf "$CS_TMP" 2>/dev/null || true
+    [[ -n "${CS_BUF:-}" ]] && rm -rf "$CS_BUF" 2>/dev/null || true
+}
+
+_run_cleanup() {
+    env PROJECT_ROOT="$PROJECT_ROOT" \
+        LYREBIRD_RECORDING_DIR="$CS_TMP/rec" \
+        LYREBIRD_LOG_DIR="$CS_TMP/logs" \
+        DRY_RUN=false \
+        "$@" \
+        bash -c 'set -euo pipefail; source "$PROJECT_ROOT/lyrebird-storage.sh"; cleanup_recordings 2>&1'
+}
+
+@test "recordings with broken-clock (1970) mtimes are KEPT by age-based cleanup" {
+    # Written while the clock was unsynced: mtime says 1970, real age is minutes.
+    touch -d @1000000 "$CS_TMP/rec/fresh-but-1970.wav"
+    # A control file with a sane, genuinely expired mtime.
+    touch -d "45 days ago" "$CS_TMP/rec/genuinely-old.wav"
+
+    run _run_cleanup
+    [ "$status" -eq 0 ]
+    [ -f "$CS_TMP/rec/fresh-but-1970.wav" ]        # broken-clock file survives
+    [ ! -f "$CS_TMP/rec/genuinely-old.wav" ]       # real retention still works
+    [[ "$output" == *"pre-"*"mtimes"* ]]           # and it says so
+}
+
+@test "age-based cleanup is skipped entirely while the system clock is unsynced" {
+    touch -d "45 days ago" "$CS_TMP/rec/old.wav"
+    # date shim: the system "clock" reads 1000 (long before CLOCK_SANE_EPOCH).
+    cat > "$CS_TMP/bin/date" <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "+%s" ]]; then echo 1000; else exec /bin/date "$@"; fi
+EOF
+    chmod +x "$CS_TMP/bin/date"
+
+    run _run_cleanup PATH="$CS_TMP/bin:$PATH"
+    [ "$status" -eq 0 ]
+    [ -f "$CS_TMP/rec/old.wav" ]                   # nothing deleted blind
+    [[ "$output" == *"skipping age-based"* ]]
+}
+
+@test "emergency cleanup still deletes broken-clock recordings when the disk is full" {
+    touch -d @1000000 "$CS_TMP/rec/fresh-but-1970.wav"
+    CS_BUF="$(mktemp -d /tmp/lyrebird-cs-buffer.XXXXXX)"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" \
+        LYREBIRD_RECORDING_DIR="$CS_TMP/rec" \
+        LYREBIRD_LOG_DIR="$CS_TMP/logs" \
+        LYREBIRD_BUFFER_DIR="$CS_BUF" \
+        DRY_RUN=false \
+        bash -c 'set -euo pipefail; source "$PROJECT_ROOT/lyrebird-storage.sh"; emergency_cleanup 2>&1'
+    [ "$status" -eq 0 ]
+    [ ! -f "$CS_TMP/rec/fresh-but-1970.wav" ]      # emergency is size-driven, not gated
+}
+
+@test "retention keeps files younger than the retention window (control)" {
+    touch "$CS_TMP/rec/today.wav"
+    touch -d "5 days ago" "$CS_TMP/rec/recent.wav"
+
+    run _run_cleanup
+    [ "$status" -eq 0 ]
+    [ -f "$CS_TMP/rec/today.wav" ]
+    [ -f "$CS_TMP/rec/recent.wav" ]
+}

--- a/tests/test_storage_inodes.bats
+++ b/tests/test_storage_inodes.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Inode-exhaustion detection tests (resource-exhaustion domain).
+#
+# A recorder writing many small files exhausts INODES long before blocks: every
+# write fails ENOSPC while block-based monitoring still reports the disk "OK",
+# so cleanup never runs -- silent recording failure on an unattended node.
+# cmd_monitor must treat inode pressure like block pressure.
+
+setup() {
+    TEST_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+    PROJECT_ROOT="$( cd "$TEST_DIR/.." && pwd )"
+    IN_TMP="$(mktemp -d)"
+    mkdir -p "$IN_TMP/bin" "$IN_TMP/rec" "$IN_TMP/logs"
+    IN_BUF="$(mktemp -d /tmp/lyrebird-inode-buffer.XXXXXX)"
+}
+
+teardown() {
+    rm -rf "$IN_TMP" "$IN_BUF" 2>/dev/null || true
+}
+
+# Fake df: blocks at $1%, inodes at $2%.
+_write_df() {
+    local block_pct="$1" inode_pct="$2"
+    cat > "$IN_TMP/bin/df" <<EOF
+#!/bin/bash
+for a in "\$@"; do
+    case "\$a" in
+        -*i*) echo "Filesystem Inodes IUsed IFree IUse% Mounted on"
+              echo "/dev/root 1000000 $((inode_pct * 10000)) $(( (100 - inode_pct) * 10000 )) ${inode_pct}% /"
+              exit 0 ;;
+    esac
+done
+echo "Filesystem 1024-blocks Used Available Capacity Mounted on"
+echo "/dev/root 1000000 $((block_pct * 10000)) $(( (100 - block_pct) * 10000 )) ${block_pct}% /"
+EOF
+    chmod +x "$IN_TMP/bin/df"
+}
+
+_run_monitor() {
+    env PROJECT_ROOT="$PROJECT_ROOT" PATH="$IN_TMP/bin:$PATH" \
+        LYREBIRD_RECORDING_DIR="$IN_TMP/rec" LYREBIRD_LOG_DIR="$IN_TMP/logs" \
+        LYREBIRD_BUFFER_DIR="$IN_BUF" DRY_RUN=true \
+        bash -c 'set -euo pipefail; source "$PROJECT_ROOT/lyrebird-storage.sh"; cmd_monitor 2>&1'
+}
+
+@test "monitor detects inode exhaustion even when block usage looks healthy" {
+    _write_df 40 99
+    run _run_monitor
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"EMERGENCY"* ]]
+    [[ "$output" == *"inodes 99%"* ]]
+}
+
+@test "monitor escalates to CRITICAL on high inode usage" {
+    _write_df 40 91
+    run _run_monitor
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CRITICAL"* ]]
+}
+
+@test "monitor stays quiet when both blocks and inodes are healthy" {
+    _write_df 40 20
+    run _run_monitor
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"EMERGENCY"* ]]
+    [[ "$output" != *"CRITICAL"* ]]
+    [[ "$output" != *"WARNING"* ]]
+}
+
+@test "unknown inode accounting (btrfs '-') is treated as no pressure, not an emergency" {
+    cat > "$IN_TMP/bin/df" <<'EOF'
+#!/bin/bash
+for a in "$@"; do
+    case "$a" in
+        -*i*) echo "Filesystem Inodes IUsed IFree IUse% Mounted on"
+              echo "/dev/root 0 0 0 - /"
+              exit 0 ;;
+    esac
+done
+echo "Filesystem 1024-blocks Used Available Capacity Mounted on"
+echo "/dev/root 1000000 400000 600000 40% /"
+EOF
+    chmod +x "$IN_TMP/bin/df"
+    run _run_monitor
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"EMERGENCY"* ]]
+    [[ "$output" != *"CRITICAL"* ]]
+}

--- a/usb-audio-mapper.sh
+++ b/usb-audio-mapper.sh
@@ -317,7 +317,7 @@ get_usb_physical_port() {
                     debug "Processing udevadm DEVPATH: $devpath_from_udev"
 
                     # Extract the LAST USB port pattern (most specific)
-                    base_port_path=$(echo "$devpath_from_udev" | grep -oE '[0-9]+-[0-9]+(\.[0-9]+)*' | tail -n1)
+                    base_port_path=$(echo "$devpath_from_udev" | grep -oE '[0-9]+-[0-9]+(\.[0-9]+)*' | tail -n1) || true
 
                     if [ -n "$base_port_path" ]; then
                         debug "Extracted port from udevadm: $base_port_path"


### PR DESCRIPTION
## Summary

Third adversarial, hardware-free reliability pass focused on what an unattended field node hits over weeks/months: clock steps, corrupt config, resource exhaustion, and streams that look alive while recording nothing. Every finding was reproduced with a runnable artifact before fixing, and every fix ships with a regression test that fails on the previous code. Suite grew **528 → 579 tests**, all green under the real CI gate (`bash -n`, ShellCheck v0.11.0 `--severity=warning`, bats); details recorded in `docs/ENGINEERING-REVIEW-2026-07.md` §8.

### Deferred trio — closed with simulation proof
- **Deep health check (H9):** `monitor_streams` now probes the MediaMTX API for each path's readiness, not just the wrapper PID. A stream not-ready for 3 consecutive monitor runs (hung FFmpeg, endless backoff) is restarted within the existing cron budget. API blips never strike a stream; `DEEP_HEALTH_CHECK_ENABLED=false` restores the old behavior.
- **Deprecated JSON fields:** all five `"ready":true` grep sites now tolerate both the deprecated (`ready`) and current (`available`) shapes, preferring the new field — a future MediaMTX dropping `ready` no longer reads as "every stream dead."
- **Monotonic timing:** wrapper backoff/run-time, the cron restart budget, and silence tracking read `/proc/uptime` instead of wall-clock `date`. NTP steps on RTC-less Pis no longer count healthy runs as failures, void the anti-storm budget, or fire false DEAD MIC alerts. Proven under simulated forward/backward clock jumps.

### New findings, reproduced and fixed
- **CRITICAL — corrupt device config aborted `start`:** a config truncated by power loss or SD-card wear hit a syntax error under errexit → no streams on the next unattended boot. Now syntax-checked, ignored if corrupt, sourced errexit-safe if valid.
- **Broken-clock mass deletion:** recordings written while the clock read 1970 were deleted as "56 years old" the moment NTP synced. Age-based retention now skips pre-sane-clock files and unsynced clocks; emergency size-based cleanup is proven exempt.
- **Silent-abort sweep (15 sites, 7 scripts):** `var=$(cmd | grep …)` under `set -euo pipefail` killed whole runs on zero matches — an unsynced NTP daemon aborted diagnostics, an idle server aborted status counts, MediaMTX exiting mid-scrape left a stale `.prom`, a service file without `Environment=` aborted updates mid-restore.
- **Non-numeric env knobs:** `CRON_RESTART_MAX_PER_HOUR=unlimited` killed every cron monitor pass with "unbound variable"; 37 numeric knobs are now coerced with valid overrides preserved.
- **Inode exhaustion:** storage monitoring now applies the warn/critical/emergency thresholds to `df -Pi` too — many small files exhaust inodes long before blocks.
- **Stale-scrape detection:** every metrics scrape embeds `lyrebird_scrape_timestamp_seconds` so a dead exporter is alertable.

### Versions & docs
`lyrebird-stream-manager.sh` 1.4.3 → 1.5.0 · `lyrebird-metrics.sh` 1.1.0 → 1.2.0 · `lyrebird-storage.sh` 1.0.0 → 1.1.0. CHANGELOG, engineering review §8, and README (new knobs, typo-safe config behavior, inode + broken-clock protection) updated.

## Test plan
- [x] `bash -n` clean on all 11 scripts
- [x] ShellCheck v0.11.0 (CI pin) clean at `--severity=warning` with `--external-sources --shell=bash`
- [x] Full bats suite: 579/579 green (51 new tests across 8 new/extended files)
- [x] Every fix verified fail-before/pass-after via `git stash` runs
- [x] No public CLI or config-format changes; new knobs are opt-out with safe defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bVJ58xNSgCcbgF6qzbBxP

---
_Generated by [Claude Code](https://claude.ai/code/session_012bVJ58xNSgCcbgF6qzbBxP)_